### PR TITLE
show example that combines GitHub and Slack

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,17 @@
 
 See [docs/deploy.md](docs/deploy.md) if you would like to run your own instance of this app.
 
+# GitHub Help
+
+The robot listens to [GitHub Webhooks](https://developer.github.com/webhooks/) using `robot.on('${event_name}.${optional_event_action}', ({payload, github}) => )`.
+
+The various values for `${event_name}` are [listed here](https://developer.github.com/webhooks/#events) and `${optional_event_action}` is the `action` field in the JSON response.
+
+For example, `robot.on('issue.created', () => console.log('Issue created'))`.
+
+You can use the `github` field in the callback to make additional API requests using the [@octokit/rest](https://octokit.github.io/rest.js/) library.
+
+
 
 # Slack Help
 

--- a/index.js
+++ b/index.js
@@ -81,7 +81,7 @@ module.exports = (robot) => {
   // })
 
   // If someone submits a Pull Request check if it has a reviewer
-  function getSlackUserByGithubIdOrNull(githubId) {
+  function getSlackUserByGithubIdOrNull (githubId) {
     return robot.slackAdapter.getBrain().users.filter(user => {
       const {fields} = user.profile
       if (fields) { // Not all users have fields
@@ -94,8 +94,8 @@ module.exports = (robot) => {
       }
     })[0]
   }
-  async function notifySlackUserWhenPullRequestOpened({payload, github}) {
-    const {number, html_url} = payload.pull_request
+  async function notifySlackUserWhenPullRequestOpened ({payload, github}) {
+    const {number, html_url: htmlUrl} = payload.pull_request
     const {name, owner: {login}} = payload.repository
     const senderLogin = payload.sender.login
     const {data: {users: reviewRequests}} = await github.pullRequests.getReviewRequests({
@@ -106,11 +106,10 @@ module.exports = (robot) => {
 
     const slackUser = getSlackUserByGithubIdOrNull(senderLogin)
     if (slackUser && reviewRequests.length === 0) {
-      await robot.slackAdapter.sendDM(slackUser.id, `I noticed you submitted a Pull Request at ${html_url} but did not include any reviewers. *Consider adding a reviewer*.\n\n You can edit my code at https://github.com/openstax/staxbot or create an Issue for discussion.`)
+      await robot.slackAdapter.sendDM(slackUser.id, `I noticed you submitted a Pull Request at ${htmlUrl} but did not include any reviewers. *Consider adding a reviewer*.\n\n You can edit my code at https://github.com/openstax/staxbot or create an Issue for discussion.`)
     } else {
       robot.log(`Could not find slack user with GitHub id ${senderLogin}. Ask them to update their profile`)
     }
-
   }
   robot.on('pull_request.opened', notifySlackUserWhenPullRequestOpened)
   robot.on('pull_request.reopened', notifySlackUserWhenPullRequestOpened)

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -105,6 +105,10 @@ module.exports = (robot) => {
       const ts = this.getMessageTimestamp(message)
       return SlackWebAPI.reactions.remove(reactionEmoji, {channel: message.channel, timestamp: ts})
     }
+    async sendDM (userId, message) {
+      const {channel: {id: dmChannelId}} = await SlackWebAPI.im.open(userId)
+      await SlackAPI.sendMessage(message, dmChannelId)
+    }
   }()
 
   // The client will emit an RTM.AUTHENTICATED event on successful connection, with the `rtm.start` payload


### PR DESCRIPTION
This sends a Slack message to any user that creates a Pull Request. It uses the "GitHub Username" field in your Slack Profile to try to find you.

![image](https://user-images.githubusercontent.com/253202/35791407-c04a6d56-0a15-11e8-8790-c2d0b4a73d0b.png)


# TODO

- [ ] post in a channel (like `#help` if the Slack user cannot be determined)