### PR TITLE
disable link unfurling for DM

### DIFF
--- a/index.js
+++ b/index.js
@@ -117,7 +117,7 @@ module.exports = (robot) => {
     if (reviewRequests.length === 0) {
       if (slackUser) {
         robot.log(`Notifying ${senderLogin} that they opened a Pull Request with no reviewers`)
-        await robot.slackAdapter.sendDM(slackUser.id, `I noticed you submitted a Pull Request at ${htmlUrl} but did not include any reviewers. *Consider adding a reviewer*.\n\n You can edit my code at https://github.com/openstax/staxly or create an Issue for discussion.`)
+        await robot.slackAdapter.sendDM(slackUser.id, `I noticed you submitted a Pull Request at ${htmlUrl} but did not include any reviewers. *Consider adding a reviewer*.\n\n You can edit my code at https://github.com/openstax/staxly or create an Issue for discussion.`, {unfurl_links: false})
       } else {
         robot.log(`Could not find slack user with GitHub id ${senderLogin}. Ask them to update their profile`)
       }

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -105,9 +105,9 @@ module.exports = (robot) => {
       const ts = this.getMessageTimestamp(message)
       return SlackWebAPI.reactions.remove(reactionEmoji, {channel: message.channel, timestamp: ts})
     }
-    async sendDM (userId, message) {
+    async sendDM (userId, message, options) {
       const {channel: {id: dmChannelId}} = await SlackWebAPI.im.open(userId)
-      await SlackAPI.sendMessage(message, dmChannelId)
+      await SlackAPI.sendMessage(message, dmChannelId, options)
     }
   }()
 


### PR DESCRIPTION
Uses https://api.slack.com/methods/chat.postMessage

Before:

![image](https://user-images.githubusercontent.com/253202/36110970-91268568-0ff2-11e8-8347-ad4b4390a715.png)

After:

![image](https://user-images.githubusercontent.com/253202/36110999-a7a77e6e-0ff2-11e8-8123-21c7475f5cfd.png)


# Failure

This caused the following exception:

```
$ docker-compose logs

probot_1  | 17:44:40.678Z  INFO probot: Notifying philschatz that they opened a Pull Request with no reviewers
probot_1  | /app/node_modules/@slack/client/lib/clients/rtm/client.js:876
probot_1  |       responseHandler.fulfill(res);
probot_1  |                       ^
probot_1  | 
probot_1  | TypeError: responseHandler.fulfill is not a function
probot_1  |     at RTMClient._handleMsgResponse (/app/node_modules/@slack/client/lib/clients/rtm/client.js:876:23)
probot_1  |     at RTMClient.handleMessageAck [as _handleMessageAck] (/app/node_modules/@slack/client/lib/clients/rtm/client.js:532:12)
probot_1  |     at RTMClient._handleWsMessageViaEventHandler (/app/node_modules/@slack/client/lib/clients/rtm/client.js:476:12)
probot_1  |     at RTMClient.handleWsMessage (/app/node_modules/@slack/client/lib/clients/rtm/client.js:436:10)
probot_1  |     at WebSocket.wrapper (/app/node_modules/lodash/lodash.js:4968:19)
probot_1  |     at emitTwo (events.js:126:13)
probot_1  |     at WebSocket.emit (events.js:214:7)
probot_1  |     at Receiver.ontext (/app/node_modules/ws/lib/WebSocket.js:841:10)
probot_1  |     at /app/node_modules/ws/lib/Receiver.js:536:18
probot_1  |     at Receiver.applyExtensions (/app/node_modules/ws/lib/Receiver.js:371:5)
probot_1  |     at /app/node_modules/ws/lib/Receiver.js:508:14
probot_1  |     at Receiver.flush (/app/node_modules/ws/lib/Receiver.js:347:3)
probot_1  |     at Receiver.finish (/app/node_modules/ws/lib/Receiver.js:541:12)
probot_1  |     at Receiver.expectHandler (/app/node_modules/ws/lib/Receiver.js:499:31)
probot_1  |     at Receiver.add (/app/node_modules/ws/lib/Receiver.js:103:24)
probot_1  |     at TLSSocket.realHandler (/app/node_modules/ws/lib/WebSocket.js:825:20)
probot_1  |     at emitOne (events.js:116:13)
probot_1  |     at TLSSocket.emit (events.js:211:7)
probot_1  |     at addChunk (_stream_readable.js:263:12)
probot_1  |     at readableAddChunk (_stream_readable.js:250:11)
probot_1  |     at TLSSocket.Readable.push (_stream_readable.js:208:10)
probot_1  |     at TLSWrap.onread (net.js:594:20)
```