### PR TITLE
add/move Project Cards when Issues/PullRequests change

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,6 +6,7 @@ module.exports = (robot) => {
 
   // Plugins that we use
   require('./src/slack-api')(robot)
+  require('./src/auto-cards')(robot)
   require('autolabeler')(robot)
   require('first-pr-merge')(robot)
   require('new-issue-welcome')(robot)

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "nodemon": "^1.14.11",
     "probot": "^5.0.0",
     "probot-app-todos": "^1.0.5",
+    "probot-config": "^0.1.0",
     "release-notifier": "github:release-notifier/release-notifier",
     "request-info": "github:behaviorbot/request-info",
     "unfurl": "github:probot/unfurl",

--- a/src/auto-cards.js
+++ b/src/auto-cards.js
@@ -1,0 +1,132 @@
+const getConfig = require('probot-config')
+
+const COLUMN_TO_DO = 1
+const COLUMN_IN_PROGRESS = 2
+const COLUMN_DONE = 3
+
+const PROJECT_REPOSITORY = 'REPOSITORY'
+const PROJECT_ORGANIZATION = 'ORGANIZATION'
+
+function findColumnId (columnKey, config, columns) {
+  const {index, name} = config.project.columns[columnKey]
+  let column
+  if (typeof index !== 'undefined') {
+    column = columns[index]
+  } else if (name) {
+    column = columns.filter((column) => column.name === name)[0]
+  }
+  if (column) {
+    return column.id
+  } else {
+    throw new Error(`Error: Unable to find project column "${columnKey}". Here is the config: ${JSON.stringify(config.project.columns)}`)
+  }
+}
+
+module.exports = (robot) => {
+  robot.on('issues.opened', curried('Issue', COLUMN_TO_DO))
+  robot.on('issues.reopened', curried('Issue', COLUMN_TO_DO))
+  robot.on('issues.closed', curried('Issue', COLUMN_DONE))
+
+  robot.on('pull_request.opened', curried('PullRequest', COLUMN_IN_PROGRESS))
+  robot.on('pull_request.merged', curried('PullRequest', COLUMN_DONE))
+  robot.on('pull_request.closed', curried('PullRequest', COLUMN_DONE))
+  robot.on('pull_request.reopened', curried('PullRequest', COLUMN_IN_PROGRESS))
+
+  function curried (issueType, columnType) {
+    return async (context) => {
+      let id
+      let url
+      switch (issueType) {
+        case 'Issue':
+          id = context.payload.issue.id
+          url = context.payload.issue.url
+          break
+        case 'PullRequest':
+          id = context.payload.pull_request.id
+          url = context.payload.pull_request.issue_url
+          break
+        default:
+          throw new Error('BUG: invalid issueType')
+      }
+      putCardInColumn(issueType, columnType, context, id, url)
+    }
+  }
+
+  async function putCardInColumn (issueType, columnType, context, issueId, issueUrl) {
+    const {payload, github} = context
+    const config = await getConfig(context, 'config.yml')
+    let projectId
+    let columns
+    let todoColumnId
+    let doingColumnId
+    let doneColumnId
+    if (config && config.project) {
+      // get all Projects
+      let projects
+      switch (config.project.type) {
+        case PROJECT_REPOSITORY:
+          projects = (await github.projects.getRepoProjects({owner: payload.repository.owner.login, repo: payload.repository.name})).data
+          break
+        case PROJECT_ORGANIZATION:
+          projects = (await github.projects.getOrgProjects({org: payload.repository.owner.login})).data
+          break
+        default:
+          throw new Error(`BUG: Repository is misconfigured. Invalid project type`)
+      }
+      // Find the project that matches
+      let project
+      if (config.project.number) {
+        project = projects.filter((project) => project.number === config.project.number)[0]
+      }
+      if (!project) {
+        throw new Error(`Error: Unable to find project. Here is the config: ${JSON.stringify(config.project)}`)
+      }
+
+      // Find all of the columns
+      projectId = project.id
+
+      columns = (await github.projects.getProjectColumns({project_id: projectId})).data
+
+      todoColumnId = findColumnId('todo', config, columns)
+      doingColumnId = findColumnId('doing', config, columns)
+      doneColumnId = findColumnId('done', config, columns)
+    }
+
+    let destinationColumnId
+    switch (columnType) {
+      case COLUMN_TO_DO:
+        destinationColumnId = todoColumnId
+        break
+      case COLUMN_IN_PROGRESS:
+        destinationColumnId = doingColumnId
+        break
+      case COLUMN_DONE:
+        destinationColumnId = doneColumnId
+        break
+      default:
+        throw new Error('BUG: invalid column type')
+    }
+
+    // If there is no destination to move the Issue/Pull Request to then stop.
+    // This can occur when, for example, you do not want new Issues to
+    // automatically show up in the Todo column
+    if (!destinationColumnId) {
+      return
+    }
+
+    // add a new card (if it does not exist)
+    let allCards = []
+    for (const column of columns) {
+      const data = await github.projects.getProjectCards({column_id: column.id})
+      allCards = allCards.concat(data.data)
+    }
+
+    let card = allCards.filter((card) => card.content_url === issueUrl)[0] // may be null
+    if (card) {
+      // Move the card to the todoColumn
+      await github.projects.moveProjectCard({column_id: destinationColumnId, id: card.id, position: 'top'})
+    } else {
+      card = await github.projects.createProjectCard({column_id: destinationColumnId, content_id: issueId, content_type: issueType})
+    }
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2858,7 +2858,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
+js-yaml@^3.10.0, js-yaml@^3.5.1, js-yaml@^3.7.0, js-yaml@^3.9.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3868,6 +3868,12 @@ probot-app-todos@^1.0.5:
 "probot-attachments@github:probot/attachments":
   version "1.0.0"
   resolved "https://codeload.github.com/probot/attachments/tar.gz/bfeb5d0e9def50c5cd69cbbaf1db1687b38cc5d2"
+
+probot-config@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/probot-config/-/probot-config-0.1.0.tgz#b6ef11ccc468e7f28e06deb68b34e093b7c7e88e"
+  dependencies:
+    js-yaml "^3.10.0"
 
 probot@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
fixes #15

This allows a repository to configure which Project its Issues and Pull Requests should be sent to. It also allows the repository to configure which column an Issue or Pull Request should move to when the state changes.

Also, it uses https://github.com/getsentry/probot-config so instead of copying and pasting a config into each repository, you can just "import" a config from another repository.

# Animation

![project-issues](https://user-images.githubusercontent.com/253202/36290898-ef958b26-1295-11e8-9baf-6209d1f0aef2.gif)
