### PR TITLE
Automatically Create Cards when reacting to Slack Message

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ PRIVATE_KEY_PATH=cert.pem
 
 # Token for connecting to Slack
 SLACK_BOT_TOKEN=
+
+# Number that represents which GitHub install to use when Slack is responding to messages
+SLACK_GITHUB_INSTALL_ID=

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 These are features coded into the bot:
 
+- automatically create a Card when a user reacts with a `:github:` and link to the slack chat
 - link-back : When someone mentions a channel in a message, that channel gets a link back to the original message
   - This is useful for notifying multiple groups, or casually asking for help
 - Reminder to add a Pull Request Reviewer

--- a/config.json
+++ b/config.json
@@ -1,0 +1,5 @@
+{
+  "slackChannelsToProjects": [
+    {"slackChannelName": "cnx", "githubProjectOrg": "openstax", "githubProjectNumber": 1}
+  ]
+}

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const SLACK_CHANNEL_REGEXP = /<#([^>|]+)\|([^>]+)>/g // Parse "foo <#C0LA54Q5C|book-tools> bar"
 const CRITSIT_PREFIX_REGEXP = /^[xy]-/ // Any channel beginning with "x-" or "y-" is a critsit and don't try to invite myself to that channel
 
+const STAXLY_CONFIG = require('./config.json')
+
 module.exports = (robot) => {
   robot.events.setMaxListeners(100) // Since we use multiple plugins
 
@@ -85,7 +87,6 @@ module.exports = (robot) => {
   // with the contents of the Slack message and a link to the Slack message
   //
   // See https://api.slack.com/methods/conversations.history#retrieving_a_single_message
-  const SLACK_CARD_CREATION = JSON.parse(process.env['CARD_CREATION_JSON'])
   robot.slackAdapter.on('reaction_added', async ({payload, github, slack, slackWeb}) => {
     const {reaction, item} = payload
     if ((reaction === 'evergreen_tree' || reaction === 'github') && item.type === 'message') {
@@ -100,7 +101,7 @@ module.exports = (robot) => {
       }
 
       const channel = robot.slackAdapter.getChannelById(item.channel)
-      const slackCardConfig = SLACK_CARD_CREATION.filter(({slackChannel}) => slackChannel === channel.name)[0]
+      const slackCardConfig = STAXLY_CONFIG.slackChannelsToProjects.filter(({slackChannelName}) => slackChannelName === channel.name)[0]
       if (channel && slackCardConfig) {
         // Create a new Note Card on the Project
         const permalink = robot.slackAdapter.getMessagePermalink(channel.id, theMessage.ts)

--- a/index.js
+++ b/index.js
@@ -90,6 +90,8 @@ module.exports = (robot) => {
   robot.slackAdapter.on('reaction_added', async ({payload, github, slack, slackWeb}) => {
     const {reaction, item} = payload
     if ((reaction === 'evergreen_tree' || reaction === 'github') && item.type === 'message') {
+      robot.log(`Noticed reaction`)
+
       // retrieve the message
       const theMessage = (await slackWeb.api.makeAPICall('channels.history', {channel: item.channel, latest: item.ts, inclusive: true, count: 1})).messages[0]
       const {reactions, text: messageText} = theMessage
@@ -103,6 +105,7 @@ module.exports = (robot) => {
       const channel = robot.slackAdapter.getChannelById(item.channel)
       const slackCardConfig = STAXLY_CONFIG.slackChannelsToProjects.filter(({slackChannelName}) => slackChannelName === channel.name)[0]
       if (channel && slackCardConfig) {
+        robot.log(`Creating Card because of reaction`)
         // Create a new Note Card on the Project
         const permalink = robot.slackAdapter.getMessagePermalink(channel.id, theMessage.ts)
 
@@ -117,6 +120,9 @@ module.exports = (robot) => {
         await github.projects.createProjectCard({column_id: projectColumn.id, note: noteBody})
 
         robot.slackAdapter.addReaction('link', {channel: channel.id, ts: theMessage.ts})
+      } else {
+        const channel = robot.slackAdapter.getChannelById(item.channel)
+        robot.log(`Channel "${channel.name}" is not configured for reactions`)
       }
     }
   })

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -18,17 +18,28 @@
 const {RtmClient, WebClient, CLIENT_EVENTS, RTM_EVENTS} = require('@slack/client')
 const EventEmitter = require('promise-events')
 
-const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN || ''
+const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN
+const SLACK_GITHUB_INSTALL_ID = process.env.SLACK_GITHUB_INSTALL_ID
 
 module.exports = (robot) => {
   if (!SLACK_BOT_TOKEN) {
     robot.log.error('SLACK_BOT_TOKEN missing, skipping Slack integration')
     process.exit(111)
   }
+  if (!SLACK_GITHUB_INSTALL_ID) {
+    robot.log.error('SLACK_GITHUB_INSTALL_ID missing. This is needed to know which authentication to use when creating GitHub Issues/Cards. It can be found in the probot trace output for /installations when LOG_LEVEL=trace')
+    process.exit(111)
+  }
 
-  function emit (name, payload) {
+  let authenticatedGitHubClient
+
+  async function emit (name, payload) {
+    if (!authenticatedGitHubClient) {
+      authenticatedGitHubClient = await robot.auth(SLACK_GITHUB_INSTALL_ID)
+    }
     const value = {
       payload,
+      github: authenticatedGitHubClient,
       slack: SlackAPI,
       slackWeb: SlackWebAPI
     }
@@ -80,6 +91,17 @@ module.exports = (robot) => {
       }
       return user
     }
+    getGithubUserBySlackUserIdOrNull (slackUserId) {
+      const slackUser = this.getUserById(slackUserId)
+      const {fields} = slackUser.profile
+      if (fields) { // Not all users have fields
+        const githubField = fields['Xf0MQDURNX']
+        if (githubField) {
+          return githubField.value
+        }
+      }
+    }
+
     getMessageTimestamp (message) {
       switch (message.subtype) {
         case 'message_changed':
@@ -92,6 +114,23 @@ module.exports = (robot) => {
           throw new Error(`BUG: Cannot get timestamp for a deleted message. Well, I can but you should not be doing things based on deleted messages`)
       }
     }
+    getMessagePermalink (channelId, messageTs) {
+      return `https://${this.getBrain().team.domain}.slack.com/archives/${channelId}/p${messageTs.replace('.', '')}`
+    }
+    convertTextToGitHub (text) {
+      const USER_REGEXP = /<@([^>]*)/
+      let match
+      while ((match = USER_REGEXP.exec(text)) != null) {
+        const slackUserId = match[1]
+        const githubUserId = this.getGithubUserBySlackUserIdOrNull(slackUserId)
+        if (githubUserId) {
+          text = text.replace(`<@${slackUserId}>`, `@${githubUserId}`)
+        } else {
+          text = text.replace(`<@${slackUserId}>`, `${this.getUserById(slackUserId).name}`)
+        }
+      }
+      return text
+    }
     async addReaction (reactionEmoji, message) {
       const ts = this.getMessageTimestamp(message)
       try {
@@ -99,6 +138,7 @@ module.exports = (robot) => {
       } catch (err) {
         // already reacted
         robot.log.trace(`Slack already reacted to the message`)
+        robot.log.trace(err)
       }
     }
     async removeReaction (reactionEmoji, message) {


### PR DESCRIPTION
When a user reacts to a Slack message in a channel with `:github:` or `:evergreen_tree:` the bot creates a Card in the Github Project linked to the channel. It also links to the original message in Slack so you can keep the context when working on the Issue.

This makes it suuper simple to create new Issues and keep the context.

(inspired by https://github.com/18F/hubot-slack-github-issues)

# Screenshots

![autocreate-cards](https://user-images.githubusercontent.com/253202/36339066-3afefb88-138b-11e8-8194-6c74de55872d.gif)


**Note:** This requires manually linking a channel to a GitHub Project (currently through `/config.json`. But maybe the Official GitHub Slack app could do it better 😄 

/cc @pumazi