### PR TITLE
Add automatically-managed settings

### DIFF
--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -1,0 +1,73 @@
+# These settings are synced to GitHub by https://probot.github.io/apps/settings/
+
+repository:
+  # See https://developer.github.com/v3/repos/#edit for all available settings.
+
+  # The name of the repository. Changing this will rename the repository
+  name: staxly
+
+  # A short description of the repository that will show up on GitHub
+  description: :robot: beep boop
+
+  # A URL with more information about the repository
+  homepage: http://openstax.github.io/staxly
+
+  # A comma-separated list of topics to set on the repository
+  topics: probot
+
+  # Either `true` to make the repository private, or `false` to make it public.
+  private: false
+
+  # Either `true` to enable issues for this repository, `false` to disable them.
+  has_issues: true
+
+  # Either `true` to enable projects for this repository, or `false` to disable them.
+  # If projects are disabled for the organization, passing `true` will cause an API error.
+  has_projects: false
+
+  # Either `true` to enable the wiki for this repository, `false` to disable it.
+  has_wiki: false
+
+  # Either `true` to enable downloads for this repository, `false` to disable them.
+  has_downloads: false
+
+  # Updates the default branch for this repository.
+  default_branch: master
+
+  # Either `true` to allow squash-merging pull requests, or `false` to prevent
+  # squash-merging.
+  allow_squash_merge: true
+
+  # Either `true` to allow merging pull requests with a merge commit, or `false`
+  # to prevent merging pull requests with merge commits.
+  allow_merge_commit: true
+
+  # Either `true` to allow rebase-merging pull requests, or `false` to prevent
+  # rebase-merging.
+  allow_rebase_merge: false
+
+# Labels: define labels for Issues and Pull Requests
+# labels:
+#   - name: bug
+#     color: CC0000
+#   - name: feature
+#     color: 336699
+#   - name: first-timers-only
+#     # include the old name to rename an existing label
+#     oldname: Help Wanted
+
+# Collaborators: give specific users access to this repository.
+# collaborators:
+#   - username: philschatz
+#     # Note: Only valid on organization-owned repositories.
+#     # The permission to grant the collaborator. Can be one of:
+#     # * `pull` - can pull, but not push to or administer this repository.
+#     # * `push` - can pull and push, but not administer this repository.
+#     # * `admin` - can pull, push and administer this repository.
+#     permission: push
+
+# NOTE: The APIs needed for teams are not supported yet by GitHub Apps
+# https://developer.github.com/v3/apps/available-endpoints/
+teams:
+  - name: all
+    permission: push

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is useful for notifying multiple groups, or casually asking for help.
 
 These are 3rd-party plugins that are included in this bot:
 
+- [settings](https://github.com/probot/settings): Pull Requests for GitHub repository settings
 - [autolabeler](https://github.com/probot/autolabeler): Automatically label Issues and Pull Requests based on logic in the `.github/config.yml` file
 - [wip-bot](https://github.com/gr2m/wip-bot): Mark a Pull Request as unmergeable when `WIP` is in the PR title
 - [probot-app-todos](https://github.com/uber-workflow/probot-app-todos): Help create Issues when code contains a "TO DO" (no spaces)

--- a/index.js
+++ b/index.js
@@ -9,6 +9,7 @@ module.exports = (robot) => {
   // Plugins that we use
   require('./src/slack-api')(robot)
   require('./src/auto-cards')(robot)
+  require('probot-settings')(robot)
   require('autolabeler')(robot)
   require('first-pr-merge')(robot)
   require('new-issue-welcome')(robot)

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "probot": "^5.0.0",
     "probot-app-todos": "^1.0.5",
     "probot-config": "^0.1.0",
+    "probot-settings": "github:probot/settings",
     "release-notifier": "github:release-notifier/release-notifier",
     "request-info": "github:behaviorbot/request-info",
     "unfurl": "github:probot/unfurl",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3875,6 +3875,13 @@ probot-config@^0.1.0:
   dependencies:
     js-yaml "^3.10.0"
 
+"probot-settings@github:probot/settings":
+  version "1.0.0"
+  resolved "https://codeload.github.com/probot/settings/tar.gz/a31da10f93d15b44905bbab181b9565171622a58"
+  dependencies:
+    js-yaml "^3.7.0"
+    probot "^5.0.0"
+
 probot@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/probot/-/probot-2.0.0.tgz#0c4f11c6f1689226cc8060226629c7a82dc7f2b8"


### PR DESCRIPTION
Using https://github.com/probot/settings . This way most admin-only features can be changed by merging a Pull Request.

Note: once of the remaining things an admin can do that this cannot is add webhooks. But most 3rd-party services are moving to GitHub Apps which register their webhooks differently which makes that feature less useful than it was in the past