### PR TITLE
Switch to use project lib

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -19,3 +19,13 @@ newPRWelcomeComment: |
 # Comment to be posted to on pull requests merged by a first time user
 firstPRMergeComment: >
   Congrats on merging your first pull request! 🎉🎉🎉
+
+project:
+  type: "ORGANIZATION"
+  number: 1
+  new_issue_column:
+    index: 0
+    # name: "To do"
+  new_pull_request_column:
+    index: 1
+    # name: "In progress"

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (robot) => {
 
   // Plugins that we use
   require('./src/slack-api')(robot)
-  require('./src/auto-cards')(robot)
+  require('project-bot')(robot)
   require('probot-settings')(robot)
   require('autolabeler')(robot)
   require('first-pr-merge')(robot)

--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ module.exports = (robot) => {
   require('new-pr-welcome')(robot)
   require('request-info')(robot)
   require('unfurl')(robot)
-  require('probot-app-todos')(robot)
+  // require('probot-app-todos')(robot)
   require('release-notifier')(robot)
   require('wip-bot')(robot)
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "probot-app-todos": "^1.0.5",
     "probot-config": "^0.1.0",
     "probot-settings": "github:probot/settings",
+    "project-bot": "github:philschatz/project-bot",
     "release-notifier": "github:release-notifier/release-notifier",
     "request-info": "github:behaviorbot/request-info",
     "unfurl": "github:probot/unfurl",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3960,6 +3960,12 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
+"project-bot@github:philschatz/project-bot":
+  version "1.0.1"
+  resolved "https://codeload.github.com/philschatz/project-bot/tar.gz/ab6d8ae2018cfe8ba85c05ca0ebea34a13a668ed"
+  dependencies:
+    probot-config "^0.1.0"
+
 promise-events@^0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/promise-events/-/promise-events-0.1.4.tgz#3c88fae97e448da68f7fcf19d4ee308d6e432d5b"


### PR DESCRIPTION
... instead of the custom code. GitHub's Project Automation already moves the cards around so there is no need for that to be included in the bot. We just need new Issues/PR's to get added to the Project automatically.

This also disables the TODO-bot until it can actually create new Issues from the TODO messages in a diff