### PR TITLE
make slack optional and add route to see deployed version

### DIFF
--- a/index.js
+++ b/index.js
@@ -166,6 +166,12 @@ module.exports = (robot) => {
   // robot.on('pull_request.opened', notifySlackUserWhenPullRequestOpened)
   // robot.on('pull_request.reopened', notifySlackUserWhenPullRequestOpened)
 
+  // Show the running version
+  robot.router.get('/_version', (req, res) => {
+    // See https://devcenter.heroku.com/changelog-items/630
+    res.json({source: process.env['SOURCE_VERSION']})
+  })
+
   // For more information on building apps:
   // https://probot.github.io/docs/
 

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -49,6 +49,7 @@ module.exports = (robot) => {
     })
   }
 
+  const events = new EventEmitter()
   let rtmBrain
 
   robot.slackAdapter = new class SlackAdapter {
@@ -149,7 +150,6 @@ module.exports = (robot) => {
   robot.log.trace('Slack connecting...')
 
   // game start!
-  const events = new EventEmitter()
   const SlackAPI = new RtmClient(SLACK_BOT_TOKEN)
   const SlackWebAPI = new WebClient(SLACK_BOT_TOKEN)
 

--- a/src/slack-api.js
+++ b/src/slack-api.js
@@ -22,11 +22,9 @@ const SLACK_GITHUB_INSTALL_ID = process.env.SLACK_GITHUB_INSTALL_ID
 module.exports = (robot) => {
   if (!SLACK_BOT_TOKEN) {
     robot.log.error('SLACK_BOT_TOKEN missing, skipping Slack integration')
-    process.exit(111)
   }
   if (!SLACK_GITHUB_INSTALL_ID) {
     robot.log.error('SLACK_GITHUB_INSTALL_ID missing. This is needed to know which authentication to use when creating GitHub Issues/Cards. It can be found in the probot trace output for /installations when LOG_LEVEL=trace')
-    process.exit(111)
   }
 
   let authenticatedGitHubClient
@@ -51,12 +49,6 @@ module.exports = (robot) => {
     })
   }
 
-  robot.log.trace('Slack connecting...')
-
-  // game start!
-  const events = new EventEmitter()
-  const SlackAPI = new RtmClient(SLACK_BOT_TOKEN)
-  const SlackWebAPI = new WebClient(SLACK_BOT_TOKEN)
   let rtmBrain
 
   robot.slackAdapter = new class SlackAdapter {
@@ -148,6 +140,18 @@ module.exports = (robot) => {
       await SlackAPI.sendMessage(message, dmChannelId)
     }
   }()
+
+  if (!SLACK_BOT_TOKEN) {
+    robot.log('Skipping Slack connection because SLACK_BOT_TOKEN env var is not set')
+    return
+  }
+
+  robot.log.trace('Slack connecting...')
+
+  // game start!
+  const events = new EventEmitter()
+  const SlackAPI = new RtmClient(SLACK_BOT_TOKEN)
+  const SlackWebAPI = new WebClient(SLACK_BOT_TOKEN)
 
   // The client will emit an RTM.AUTHENTICATED event on successful connection, with the `rtm.start` payload
   SlackAPI.on(CLIENT_EVENTS.RTM.AUTHENTICATED, (rtmStartData) => {


### PR DESCRIPTION
This allows us to see which version of staxly is running. This PR is also checking if heroku will automatically deploy a Review app (https://github.com/apps/staxly-dev) so devs can check that their changes work in the test repos that `staxly-dev` is installed on.

Actually, #26 is a better example since it's a screncap of the whole process from start to finish

# Screencap of adding a new Feature (example)

Here is the code for the New Feature we write in the Screencap:

```js
// Add a "Hello!" message when a new Issue is created
robot.on(['issues.opened'], async(context) => {
  await context.github.issues.createComment(context.issue({body: 'Hello!'}))
})
// We will test it by creating an Issue in https://github.com/philschatz/test
```

![easy-dev](https://user-images.githubusercontent.com/253202/36647138-0fdf9244-1a4f-11e8-8c94-5c379aefadce.gif)