### PR TITLE
[WIP] skip posting to the general channel

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,8 @@ module.exports = (robot) => {
 
       if (channelId === message.channel) {
         // Skip posting a message when the bot is in the same channel
+      } else if (robot.getBrain().getChannelById(channelId).is_general) {
+        // Skip posting to the special #general channel since everyone is in it
       } else if (robot.slackAdapter.isMemberOfChannel(channelId)) {
         // This bot is already in the channel so post there
         robot.log(`Posting to ${channelName}`)


### PR DESCRIPTION
to reduce the clutter in that channel.

However, some folks have found this feature useful so keeping it WIP for a while.

If using staxly to post to the general channel is abused then we can merge this and then people will need to post to the general channel and mention the other channels so that it pops up in those other channels.