### PR TITLE
include a default project

### DIFF
--- a/config.json
+++ b/config.json
@@ -1,5 +1,15 @@
 {
   "slackChannelsToProjects": [
     {"slackChannelName": "cnx", "githubProjectOrg": "openstax", "githubProjectNumber": 1}
-  ]
+  ],
+  "defaultProject": {
+    "type": "ORGANIZATION",
+    "number": 1,
+    "new_issue_column": {
+      "index": 0
+    },
+    "new_pull_request_column": {
+      "index": 1
+    }
+  }
 }

--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = (robot) => {
 
   // Plugins that we use
   require('./src/slack-api')(robot)
-  require('project-bot')(robot)
+  require('project-bot')(robot, {project: STAXLY_CONFIG.defaultProject})
   require('probot-settings')(robot)
   require('autolabeler')(robot)
   require('first-pr-merge')(robot)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "probot-app-todos": "^1.0.5",
     "probot-config": "^0.1.0",
     "probot-settings": "github:probot/settings",
-    "project-bot": "github:philschatz/project-bot",
+    "project-bot": "github:philschatz/project-bot#838a001841875c1e5ae8f2d5ee2de901c6ec64a4",
     "release-notifier": "github:release-notifier/release-notifier",
     "request-info": "github:behaviorbot/request-info",
     "smee-client": "^1.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3960,9 +3960,9 @@ progress@^1.1.8:
   version "1.1.8"
   resolved "https://registry.yarnpkg.com/progress/-/progress-1.1.8.tgz#e260c78f6161cdd9b0e56cc3e0a85de17c7a57be"
 
-"project-bot@github:philschatz/project-bot":
+"project-bot@github:philschatz/project-bot#838a001841875c1e5ae8f2d5ee2de901c6ec64a4":
   version "1.0.1"
-  resolved "https://codeload.github.com/philschatz/project-bot/tar.gz/ab6d8ae2018cfe8ba85c05ca0ebea34a13a668ed"
+  resolved "https://codeload.github.com/philschatz/project-bot/tar.gz/838a001841875c1e5ae8f2d5ee2de901c6ec64a4"
   dependencies:
     probot-config "^0.1.0"
 


### PR DESCRIPTION
... for repositories if they do not have one defined.

A repository can define a Project to add Issues/PR's to but if that information is missing then we add it to a default project.

In the future these could be AND'd together to auto-add an Issue to multiple Projects where the default Project is just a quick overview of the entire organization.