### PR TITLE
update unfurl plugin

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2036,13 +2036,6 @@ getpass@^0.1.1:
   dependencies:
     assert-plus "^1.0.0"
 
-github-app@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/github-app/-/github-app-3.2.0.tgz#dfd5a4e87b75629723ba0ec63d8d0aeccb2f39a6"
-  dependencies:
-    github "^10.1.0"
-    jsonwebtoken "^7.3.0"
-
 github-webhook-handler@^0.7.0:
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/github-webhook-handler/-/github-webhook-handler-0.7.1.tgz#129a32911f0f7db16e2951cee61107965d55cf89"
@@ -2749,10 +2742,6 @@ isarray@1.0.0, isarray@^1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
 
-isemail@1.x.x:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/isemail/-/isemail-1.2.0.tgz#be03df8cc3e29de4d2c5df6501263f1fa4595e9a"
-
 isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
@@ -3389,15 +3378,6 @@ jest@^22.4.2:
     import-local "^1.0.0"
     jest-cli "^22.4.2"
 
-joi@^6.10.1:
-  version "6.10.1"
-  resolved "https://registry.yarnpkg.com/joi/-/joi-6.10.1.tgz#4d50c318079122000fe5f16af1ff8e1917b77e06"
-  dependencies:
-    hoek "2.x.x"
-    isemail "1.x.x"
-    moment "2.x.x"
-    topo "1.x.x"
-
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
@@ -3540,16 +3520,6 @@ json5@^0.5.1:
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
-
-jsonwebtoken@^7.3.0:
-  version "7.4.3"
-  resolved "https://registry.yarnpkg.com/jsonwebtoken/-/jsonwebtoken-7.4.3.tgz#77f5021de058b605a1783fa1283e99812e645638"
-  dependencies:
-    joi "^6.10.1"
-    jws "^3.1.4"
-    lodash.once "^4.0.0"
-    ms "^2.0.0"
-    xtend "^4.0.1"
 
 jsonwebtoken@^8.1.0:
   version "8.1.1"
@@ -3935,7 +3905,7 @@ mixin-deep@^1.2.0:
   dependencies:
     minimist "0.0.8"
 
-moment@2.x.x, moment@^2.10.6:
+moment@^2.10.6:
   version "2.20.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.20.1.tgz#d6eb1a46cbcc14a2b2f9434112c1ff8907f313fd"
 
@@ -3953,7 +3923,7 @@ ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
 
-ms@^2.0.0, ms@^2.1.1:
+ms@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.1.tgz#30a5864eb3ebb0a66f2ebe6d727af06a09d86e0a"
 
@@ -4542,28 +4512,6 @@ probot-config@^0.1.0:
   dependencies:
     js-yaml "^3.7.0"
     probot "^5.0.0"
-
-probot@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/probot/-/probot-2.0.0.tgz#0c4f11c6f1689226cc8060226629c7a82dc7f2b8"
-  dependencies:
-    bottleneck "^1.16.0"
-    bunyan "^1.8.12"
-    bunyan-format "^0.2.1"
-    bunyan-sentry-stream "^1.1.0"
-    cache-manager "^2.4.0"
-    commander "^2.11.0"
-    dotenv "~4.0.0"
-    express "^4.15.4"
-    github "^10.1.0"
-    github-app "^3.2.0"
-    github-webhook-handler "github:rvagg/github-webhook-handler#v0.6.1"
-    js-yaml "^3.9.1"
-    pkg-conf "^2.0.0"
-    promise-events "^0.1.3"
-    raven "^2.1.2"
-    resolve "^1.4.0"
-    semver "^5.4.1"
 
 probot@^3.0.0:
   version "3.0.3"
@@ -5626,12 +5574,6 @@ to-regex@^3.0.1:
     extend-shallow "^2.0.1"
     regex-not "^1.0.0"
 
-topo@1.x.x:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/topo/-/topo-1.1.0.tgz#e9d751615d1bb87dc865db182fa1ca0a5ef536d5"
-  dependencies:
-    hoek "2.x.x"
-
 touch@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.0.tgz#fe365f5f75ec9ed4e56825e0bb76d24ab74af83b"
@@ -5728,11 +5670,11 @@ unfurl.js@^1.1.6:
 
 "unfurl@github:probot/unfurl":
   version "1.0.0"
-  resolved "https://codeload.github.com/probot/unfurl/tar.gz/b9d45188fb696b76fca979f23a6b9eccf4e5a1a3"
+  resolved "https://codeload.github.com/probot/unfurl/tar.gz/2931ec3b8c16717fba76555b2ffdd30e3d3126e0"
   dependencies:
     ejs "^2.5.7"
     jsdom "^11.3.0"
-    probot "^2.0.0"
+    probot "^6.0.0"
     probot-attachments "github:probot/attachments"
     unfurl.js "^1.1.6"
 


### PR DESCRIPTION
Adds support for websites that do not have OpenGraph metadata: https://github.com/probot/unfurl/pull/11

![image](https://user-images.githubusercontent.com/253202/37496268-e542e0ee-2887-11e8-9c74-c320d59e834b.png)
