### PR TITLE
Automate Project Columns (for reals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,22 @@ The board that the card is added to depends on the Slack channel, and is configu
 
 <a href="https://user-images.githubusercontent.com/253202/36339066-3afefb88-138b-11e8-8194-6c74de55872d.gif"><img width="500" alt="autocreate-cards" src="https://user-images.githubusercontent.com/253202/36339066-3afefb88-138b-11e8-8194-6c74de55872d.gif"/></a>
 
-### Add/Move Project Cards when Issues/PullRequests change ([#17](https://github.com/openstax/staxly/pull/17))
+### Add/Move Project Cards when Issues/PullRequests change ([#42](https://github.com/openstax/staxly/pull/42))
 
 It is annoying to remember to add new Cards to a board and move the Cards when the Issue/Pull Request changes.
 So the card movement is now automated. Create an Issue/PullRequest and it is added to the board. Merge/Close it and it is moved to the Done column.
 
-The board that Card is added to is configured in the repository's `/.github/config.yml` which can inherit from another repository (to reduce copy/paste).
+You can move cards based on many criteria (adding labels, adding reviews, merging, assigning, etc) and it is all configured by creating a card in the Project column like the following:
 
-<a href="https://user-images.githubusercontent.com/253202/36498318-f09005c2-170b-11e8-90cb-771f4d13b884.gif"><img width="500" alt="project-issues" src="https://user-images.githubusercontent.com/253202/36498318-f09005c2-170b-11e8-90cb-771f4d13b884.gif"/></a>
+```markdown
+###### Automation Rules
+
+- `new.issue`
+- `added_label` wontfix
+```
+
+
+<a href="https://user-images.githubusercontent.com/253202/37872089-ad7d21ea-2fcd-11e8-81ba-7f3977c102cf.gif"><img width="500" alt="project-issues" src="https://user-images.githubusercontent.com/253202/37872089-ad7d21ea-2fcd-11e8-81ba-7f3977c102cf.gif"/></a>
 
 ### Move an Issue to another Repository ([#34](https://github.com/openstax/staxly/pull/34))
 

--- a/config.yml
+++ b/config.yml
@@ -1,0 +1,120 @@
+---
+automate_project_columns:
+- title: Test Repo Project
+  repo_owner: "philschatz"
+  repo_name: "test"
+  number: 1
+  id: 1292562
+  columns:
+  - title: Done
+    # index: 2 # These are 0-based
+    id: 2202275
+    rules:
+      added_label: "wontfix"
+
+
+# - title: Tutor Sprint
+#   # number: 2
+#   # org: "openstax"
+#   # id: 246802468
+#   columns:
+#   - title: "1A: Backlog Define Design Decomp"
+#     index: 1
+#     # id: 12345678
+#     rules:
+#       new.issue: true
+#   - title: "3B: CODE & PEER REVIEW"
+#     index: 6
+#     # id: 12345678
+#     rules:
+#       new.pullrequest: true
+#       reopened.pullrequest: true
+#   - title: "4: UX REVIEW"
+#     index: 7
+#     # id: 12345678
+#     rules:
+#       accepted: true
+#       merged: true
+#   - title: "5A: Functional Verification"
+#     index: 8
+#     # id: 12345678
+#     rules:
+#       assigned: true
+#   - title: "5B: Verified on QA"
+#     index: 9
+#     # id: 12345678
+#     rules:
+#       added_label: "verified"
+#   - title: "Done: Will Not Release"
+#     index: 14
+#     # id: 12345678
+#     rules:
+#       closed.pullrequest: true
+#       added_label: "wontfix"
+#
+#
+# - title: Books Sprint
+#   # number: 2
+#   # org: "openstax"
+#   # id: 246802468
+#   columns:
+#   - title: "Inbox for Prioritization"
+#     index: 1
+#     # id: 12345678
+#     rules:
+#       new.issue: true
+#   - title: "Coding"
+#     index: 4
+#     # id: 12345678
+#     rules:
+#       new.pullrequest: true
+#   - title: "QA"
+#     index: 7
+#     # id: 12345678
+#     rules:
+#       accepted: true
+#       merged: true
+#   - title: "Done"
+#     index: 8
+#     # id: 12345678
+#     rules:
+#       closed.issue: true
+#
+#
+# - title: BIT Sprint
+#   # number: 2
+#   # org: "openstax"
+#   # id: 246802468
+#   columns:
+#   - title: "Backlog Define/Design/Decomp"
+#     index: 1
+#     # id: 12345678
+#     rules:
+#       new.issue: true
+#   - title: "Doing"
+#     index: 5
+#     # id: 12345678
+#     rules:
+#       new.pullrequest: true
+#       reopened.pullrequest: true
+#   - title: "Dev Verify"
+#     index: 6
+#     # id: 12345678
+#     rules:
+#       added_reviewer: true
+#   - title: "UX Review"
+#     index: 7
+#     # id: 12345678
+#     rules:
+#       added_reviewer: "Fredasaurus"
+#   - title: "5A: Functional Verification"
+#     index: 8
+#     # id: 12345678
+#     rules:
+#       accepted: true
+#       merged: true
+#   - title: "Done Not Released"
+#     index: 13
+#     # id: 12345678
+#     rules:
+#       closed.issue: true

--- a/config.yml
+++ b/config.yml
@@ -11,6 +11,22 @@ automate_project_columns:
     id: 2202275
     rules:
       added_label: "wontfix"
+      # removed_label: "wontfix"
+
+      # assigned_to.issue: "philschatz"
+      # assigned.issue: true
+      # unassigned.issue: true
+      # closed.issue: true
+      # reopened.issue: true
+      #
+      # new.pullrequest: true
+      # assigned.pullrequest: true
+      # unassigned.pullrequest: true
+      # closed.pullrequest: true
+      # reopened.pullrequest: true
+      # added_reviewer: true
+      # accepted: true
+      # merged: true
 
 
 # - title: Tutor Sprint

--- a/config.yml
+++ b/config.yml
@@ -1,16 +1,16 @@
 ---
 automate_project_columns:
-- title: Test Repo Project
-  repo_owner: "philschatz"
-  repo_name: "test"
-  number: 1
-  id: 1292562
-  columns:
-  - title: Done
-    # index: 2 # These are 0-based
-    id: 2202275
-    rules:
-      added_label: "wontfix"
+# - title: Test Repo Project
+#   repo_owner: "philschatz"
+#   repo_name: "test"
+#   number: 1
+#   id: 1292562
+#   columns:
+#   - title: Done
+#     # index: 2 # These are 0-based
+#     id: 2202275
+#     rules:
+#       added_label: "wontfix"
       # removed_label: "wontfix"
 
       # assigned_to.issue: "philschatz"

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@slack/client": "^4.0.0",
     "autolabeler": "github:probot/autolabeler",
+    "commonmark": "^0.28.1",
     "first-pr-merge": "github:behaviorbot/first-pr-merge",
     "new-issue-welcome": "github:behaviorbot/new-issue-welcome",
     "new-pr-welcome": "github:behaviorbot/new-pr-welcome",

--- a/src/automate-project-columns.js
+++ b/src/automate-project-columns.js
@@ -36,7 +36,7 @@ const AUTOMATION_COMMANDS = [
       if (ruleValue) {
         // Verify that it matches one of the repositories listed
         const repoNames = ruleValue.split(' ')
-        debugger
+
         return repoNames.indexOf(context.payload.repository.name) >= 0
       } else {
         return true
@@ -149,7 +149,6 @@ module.exports = (robot) => {
 
   function addOrUpdateAutomationCache (context, projectId, columnId, projectCard) {
     if (!projectId) {
-      console.log(COLUMN_CACHE)
       throw new Error(`BUG: Could not find projectId for card. JSON=${JSON.stringify(projectCard)}`)
     }
     // Check if it is one of the special "Automation Rules" cards
@@ -331,7 +330,6 @@ module.exports = (robot) => {
             }
           })
         })
-
       } else {
         // Check if we need to move the Issue (or Pull request)
         const cardsForIssue = Object.values(CARD_LOOKUP[issueUrl] || {})
@@ -405,8 +403,6 @@ module.exports = (robot) => {
           }
         })
       }
-
-
     })
   })
 }

--- a/src/automate-project-columns.js
+++ b/src/automate-project-columns.js
@@ -1,0 +1,154 @@
+// - `new.issue` : When an Issue is created
+// - `new.pullrequest` : When a Pull Request is created
+// - `assigned`: When an Issue or Pull Request is assigned to a user
+// - `reopened`: When an Issue or Pull Request is reopened
+// - `reopened.pullrequest`:
+// - `added_reviewer`: (optional username or array of usernames that need to be added)
+// - `accepted`: When at least one Reviewer Accepted, and there are no Rejections on a Pull request
+// - `merged`: When a Pull Request is merged
+// - `closed.pullrequest`: When a Pull Request is closed
+// - `added_label`: (has one argument, the string representing the name of the label)
+// - `closed.issue`: When an Issue is closed
+
+const {readFileSync} = require('fs')
+const {join: pathJoin} = require('path')
+const yaml = require('js-yaml')
+
+
+const AUTOMATION_COMMANDS = [
+  {
+    webhookName: 'issues.labeled',
+    ruleName: 'added_label',
+    ruleMatcher: async function(context, ruleValue) {
+      // labels may be defined by a label or an id (for more persistence)
+      return context.payload.label.name === ruleValue || context.payload.label.id === ruleValue
+    }
+  },
+]
+
+module.exports = (robot) => {
+  const {automate_project_columns: automateProjectColumnsConfig} = yaml.safeLoad(readFileSync(pathJoin(__dirname, '..', 'config.yml')))
+
+  // Load all the Cards in memory because there is no way to lookup which projects an Issue is in
+  const CARD_LOOKUP = {} // Key is "{issue_url}" and value is [{projectId, cardId}]
+  let ORG_PROJECTS = {} // Only load this once for each org
+  let REPO_PROJECTS = {} // Only load this once for each repo
+
+  async function populateCache (context) {
+    // Loop through all the projects in the config and add them to the cache
+    for (const projectConfig of automateProjectColumnsConfig) {
+      let projectId
+      if (projectConfig.id) {
+        projectId = projectConfig.id
+      } else if (projectConfig.org && projectConfig.number) {
+        if (!ORG_PROJECTS[projectConfig.org]) {
+          const {data: projects} = await context.github.projects.getOrgProjects({org: projectConfig.org, state: 'open'})
+          ORG_PROJECTS[projectConfig.org] = projects
+        }
+        // Look up the Project in the org
+        const project = ORG_PROJECTS[projectConfig.org].filter((project) => project.number === projectConfig.number)[0]
+        projectId = project.id
+      } else if (projectConfig.repo_owner && projectConfig.repo_name && projectConfig.number) {
+        if (!REPO_PROJECTS[`${projectConfig.repo_owner}/${projectConfig.repo_name}`]) {
+          const {data: projects} = await context.github.projects.getRepoProjects({owner: projectConfig.repo_owner, repo: projectConfig.repo_name, state: 'open'})
+          REPO_PROJECTS[`${projectConfig.repo_owner}/${projectConfig.repo_name}`] = projects
+        }
+        // Look up the Project
+        const project = REPO_PROJECTS[`${projectConfig.repo_owner}/${projectConfig.repo_name}`].filter((project) => project.number === projectConfig.number)[0]
+        projectId = project.id
+      }
+
+      if (projectId) {
+        if (!projectConfig.id) {
+          robot.log.warn(`Set this to be "id: ${projectId}" for less fragility. JSON=${JSON.stringify(projectConfig)}`)
+        }
+        const {data: projectColumns} = await context.github.projects.getProjectColumns({project_id: projectId})
+        for (const projectColumn of projectColumns) {
+          const {data: projectCards} = await context.github.projects.getProjectCards({column_id: projectColumn.id})
+
+          for (const projectCard of projectCards) {
+            // Issues can belong to multiple cards
+            if (projectCard.content_url) {
+              CARD_LOOKUP[projectCard.content_url] = CARD_LOOKUP[projectCard.content_url] || {}
+              CARD_LOOKUP[projectCard.content_url][projectCard.id] = {projectId: projectId, cardId: projectCard.id, projectConfig: projectConfig}
+            }
+          }
+        }
+
+      } else {
+        robot.log.error(`Could not find project. JSON=${JSON.stringify(projectConfig)}`)
+      }
+
+    } // Finished populating the CARD_LOOKUP cache
+  }
+
+  // Register all of the automation commands
+  AUTOMATION_COMMANDS.forEach(({webhookName, ruleName, ruleMatcher}) => {
+
+    robot.on(webhookName, async function (context) {
+      await populateCache(context)
+
+      // Check if we need to move the Issue
+      const cardsForIssue = Object.values(CARD_LOOKUP[context.payload.issue.url] || {})
+
+      // At this point we need the cards and columns that need to be moved.
+      const matchedColumnInfos = cardsForIssue.map(({projectId, cardId, projectConfig}) => {
+        // Check if there are any columns that match the ruleName.
+        // If so, return the following:
+        // - ruleArgs (most of the time it is just `true`)
+        // - columnInfo
+        // - cardId
+        // - projectId
+
+        let columnInfo = null
+        let ruleValue = null
+        for (const column of projectConfig.columns) {
+          if (column.rules[ruleName]) {
+            if (columnInfo) {
+              robot.log.error(`Duplicate rule named "${ruleName}" within project config ${JSON.stringify(projectConfig)}`)
+            } else {
+              columnInfo = column
+              ruleValue = column.rules[ruleName]
+            }
+          }
+        }
+
+        if (columnInfo) {
+          return {
+            columnInfo,
+            cardId,
+            projectId,
+            ruleValue
+          }
+        } else {
+          return null
+        }
+      }).filter((info) => !!info) // remove all the nulls (ruleName not found in this projectConfig)
+
+      matchedColumnInfos.forEach(async ({columnInfo, cardId, projectId, ruleValue}) => {
+        if (await ruleMatcher(context, ruleValue)) {
+          // Move the Card
+          const {data: columns} = await context.github.projects.getProjectColumns({project_id: projectId})
+
+          // Find the correct column
+          let columnId
+          if (columnInfo.id) {
+            columnId = columnInfo.id
+          } else if (columnInfo.index) {
+            columnId = columns[columnInfo.index].id
+            robot.log.warn(`Consider identifying the column by "id: ${columnId}" rather than by index in JSON=${JSON.stringify(columnInfo)}`)
+          }
+
+          if (!columnId) {
+            robot.log.error(`Could not find column for JSON=${JSON.stringify(columnInfo)}`)
+            return
+          }
+          await context.github.projects.moveProjectCard({id: cardId, column_id: columnId, position: 'top'})
+        }
+      })
+    })
+
+
+  })
+
+}

--- a/src/automate-project-columns.js
+++ b/src/automate-project-columns.js
@@ -1,26 +1,125 @@
-// - `new.issue` : When an Issue is created
-// - `new.pullrequest` : When a Pull Request is created
-// - `assigned`: When an Issue or Pull Request is assigned to a user
-// - `reopened`: When an Issue or Pull Request is reopened
-// - `reopened.pullrequest`:
-// - `added_reviewer`: (optional username or array of usernames that need to be added)
-// - `accepted`: When at least one Reviewer Accepted, and there are no Rejections on a Pull request
-// - `merged`: When a Pull Request is merged
-// - `closed.pullrequest`: When a Pull Request is closed
-// - `added_label`: (has one argument, the string representing the name of the label)
-// - `closed.issue`: When an Issue is closed
+// - [x] `new.issue` : When an Issue is created
+// - [x] `new.pullrequest` : When a Pull Request is created
+// - [x] `assigned_to.issue`: When an Issue is assigned to a specific user
+// - [x] `assigned.issue`: When an Issue is assigned to a user (but was not before)
+// - [x] `unassigned.issue`: When an Issue is no longer assigned to a user
+// - [x] `assigned.pullrequest`: When a Pull Request is assigned to a user (but was not before)
+// - [x] `unassigned.pullrequest`: When a Pull Request is no longer assigned to a user
+// - [x] `reopened.issue`: When an Issue is reopened
+// - [x] `reopened.pullrequest`: When a Pull Request is reopened
+// - [x] `added_reviewer`: (optional username or array of usernames that need to be added)
+// - [x] `accepted`: When at least one Reviewer Accepted, and there are no Rejections on a Pull request
+// - [x] `merged`: When a Pull Request is merged
+// - [x] `closed.pullrequest`: When a Pull Request is closed
+// - [x] `added_label`: (has one argument, the string representing the name of the label)
+// - [x] `removed_label`: (has one argument, the string representing the name of the label)
+// - [x] `closed.issue`: When an Issue is closed
+// - [x] `edited.issue`
+// - [x] `milestoned.issue`
+// - [x] `demilestoned.issue`
 
 const {readFileSync} = require('fs')
 const {join: pathJoin} = require('path')
 const yaml = require('js-yaml')
 
+function ALWAYS_TRUE () { return true }
+
 const AUTOMATION_COMMANDS = [
+  { ruleName: 'edited.issue', webhookName: 'issues.edited', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'demilestoned.issue', webhookName: 'issues.demilestoned', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'milestoned.issue', webhookName: 'issues.milestoned', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'new.issue', webhookName: 'issues.opened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'new.pullrequest', webhookName: 'pull_request.opened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'reopened.pullrequest', webhookName: 'pull_request.reopened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'reopened.issue', webhookName: 'issues.reopened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'closed.issue', webhookName: 'issues.closed', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'added_reviewer', webhookName: 'pull_request.review_requested', ruleMatcher: ALWAYS_TRUE }, // See https://developer.github.com/v3/activity/events/types/#pullrequestevent to get the reviewer
   {
-    webhookName: 'issues.labeled',
+    ruleName: 'merged',
+    webhookName: 'pull_request.closed',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      // see https://developer.github.com/v3/activity/events/types/#pullrequestevent
+      return !!context.payload.pull_request.merged
+    }
+  },
+  {
+    ruleName: 'closed.pullrequest',
+    webhookName: 'pull_request.closed',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      // see https://developer.github.com/v3/activity/events/types/#pullrequestevent
+      return !context.payload.pull_request.merged
+    }
+  },
+  {
+    ruleName: 'assigned_to.issue',
+    webhookName: 'issues.assigned',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      if (ruleValue !== true) {
+        return context.payload.assignee.login === ruleValue
+      } else {
+        robot.log.error(`assigned_to.issue requires a username but it is missing`)
+      }
+    }
+  },
+  {
+    ruleName: 'assigned.issue',
+    webhookName: 'issues.assigned',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      return context.payload.issue.assignees.length === 1
+    }
+  },
+  {
+    ruleName: 'unassigned.issue',
+    webhookName: 'issues.unassigned',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      return context.payload.issue.assignees.length === 0
+    }
+  },
+  {
+    ruleName: 'assigned.pullrequest',
+    webhookName: 'pull_request.assigned',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      return context.payload.pull_request.assignees.length === 1
+    }
+  },
+  {
+    ruleName: 'unassigned.pullrequest',
+    webhookName: 'pull_request.unassigned',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      return context.payload.pull_request.assignees.length === 0
+    }
+  },
+  {
     ruleName: 'added_label',
-    ruleMatcher: async function (context, ruleValue) {
+    webhookName: 'issues.labeled',
+    ruleMatcher: async function (robot, context, ruleValue) {
       // labels may be defined by a label or an id (for more persistence)
       return context.payload.label.name === ruleValue || context.payload.label.id === ruleValue
+    }
+  },
+  {
+    ruleName: 'removed_label',
+    webhookName: 'issues.unlabeled',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      return context.payload.label.name === ruleValue || context.payload.label.id === ruleValue
+    }
+  },
+  {
+    ruleName: 'accepted',
+    webhookName: 'pull_request_review.submitted',
+    ruleMatcher: async function (robot, context, ruleValue) {
+      // See https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent
+      // Check if there are any Pending or Rejected reviews and ensure there is at least one Accepted one
+      const {data: reviews} = await context.github.pullRequests.getReviews(context.issue())
+      // Check that there is at least one Accepted
+      const hasAccepted = reviews.filter((review) => review.state === 'APPROVED').length >= 1
+      const hasRejections = reviews.filter((review) => review.state === 'REQUEST_CHANGES').length >= 1
+      const hasPending = reviews.filter((review) => review.state === 'PENDING').length >= 1
+      if (hasAccepted && !hasRejections && !hasPending) {
+        return true
+      } else {
+        return false
+      }
     }
   }
 ]
@@ -84,8 +183,9 @@ module.exports = (robot) => {
     robot.on(webhookName, async function (context) {
       await populateCache(context)
 
-      // Check if we need to move the Issue
-      const cardsForIssue = Object.values(CARD_LOOKUP[context.payload.issue.url] || {})
+      // Check if we need to move the Issue (or Pull request)
+      const issueUrl = context.payload.issue ? context.payload.issue.url : context.payload.pull_request.issue_url
+      const cardsForIssue = Object.values(CARD_LOOKUP[issueUrl] || {})
 
       // At this point we need the cards and columns that need to be moved.
       const matchedColumnInfos = cardsForIssue.map(({projectId, cardId, projectConfig}) => {
@@ -122,7 +222,7 @@ module.exports = (robot) => {
       }).filter((info) => !!info) // remove all the nulls (ruleName not found in this projectConfig)
 
       matchedColumnInfos.forEach(async ({columnInfo, cardId, projectId, ruleValue}) => {
-        if (await ruleMatcher(context, ruleValue)) {
+        if (await ruleMatcher(robot, context, ruleValue)) {
           // Move the Card
           const {data: columns} = await context.github.projects.getProjectColumns({project_id: projectId})
 

--- a/src/automate-project-columns.js
+++ b/src/automate-project-columns.js
@@ -7,16 +7,16 @@ const commonmarkParser = new commonmark.Parser()
 function ALWAYS_TRUE () { return true }
 
 const AUTOMATION_COMMANDS = [
-  { ruleName: 'edited.issue', webhookName: 'issues.edited', ruleMatcher: ALWAYS_TRUE },
-  { ruleName: 'demilestoned.issue', webhookName: 'issues.demilestoned', ruleMatcher: ALWAYS_TRUE },
-  { ruleName: 'milestoned.issue', webhookName: 'issues.milestoned', ruleMatcher: ALWAYS_TRUE },
-  { ruleName: 'reopened.pullrequest', webhookName: 'pull_request.reopened', ruleMatcher: ALWAYS_TRUE },
-  { ruleName: 'reopened.issue', webhookName: 'issues.reopened', ruleMatcher: ALWAYS_TRUE },
-  { ruleName: 'closed.issue', webhookName: 'issues.closed', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'edited_issue', webhookName: 'issues.edited', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'demilestoned_issue', webhookName: 'issues.demilestoned', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'milestoned_issue', webhookName: 'issues.milestoned', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'reopened_pullrequest', webhookName: 'pull_request.reopened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'reopened_issue', webhookName: 'issues.reopened', ruleMatcher: ALWAYS_TRUE },
+  { ruleName: 'closed_issue', webhookName: 'issues.closed', ruleMatcher: ALWAYS_TRUE },
   { ruleName: 'added_reviewer', webhookName: 'pull_request.review_requested', ruleMatcher: ALWAYS_TRUE }, // See https://developer.github.com/v3/activity/events/types/#pullrequestevent to get the reviewer
   {
     createsACard: true,
-    ruleName: 'new.issue',
+    ruleName: 'new_issue',
     webhookName: 'issues.opened',
     ruleMatcher: async function (robot, context, ruleValue) {
       if (ruleValue) {
@@ -30,7 +30,7 @@ const AUTOMATION_COMMANDS = [
   },
   {
     createsACard: true,
-    ruleName: 'new.pullrequest',
+    ruleName: 'new_pullrequest',
     webhookName: 'pull_request.opened',
     ruleMatcher: async function (robot, context, ruleValue) {
       if (ruleValue) {
@@ -44,7 +44,7 @@ const AUTOMATION_COMMANDS = [
     }
   },
   {
-    ruleName: 'merged',
+    ruleName: 'merged_pullrequest',
     webhookName: 'pull_request.closed',
     ruleMatcher: async function (robot, context, ruleValue) {
       // see https://developer.github.com/v3/activity/events/types/#pullrequestevent
@@ -52,7 +52,7 @@ const AUTOMATION_COMMANDS = [
     }
   },
   {
-    ruleName: 'closed.pullrequest',
+    ruleName: 'closed_pullrequest',
     webhookName: 'pull_request.closed',
     ruleMatcher: async function (robot, context, ruleValue) {
       // see https://developer.github.com/v3/activity/events/types/#pullrequestevent
@@ -60,7 +60,7 @@ const AUTOMATION_COMMANDS = [
     }
   },
   {
-    ruleName: 'assigned_to.issue',
+    ruleName: 'assigned_to_issue',
     webhookName: 'issues.assigned',
     ruleMatcher: async function (robot, context, ruleValue) {
       if (ruleValue !== true) {
@@ -71,28 +71,28 @@ const AUTOMATION_COMMANDS = [
     }
   },
   {
-    ruleName: 'assigned.issue',
+    ruleName: 'assigned_issue',
     webhookName: 'issues.assigned',
     ruleMatcher: async function (robot, context, ruleValue) {
       return context.payload.issue.assignees.length === 1
     }
   },
   {
-    ruleName: 'unassigned.issue',
+    ruleName: 'unassigned_issue',
     webhookName: 'issues.unassigned',
     ruleMatcher: async function (robot, context, ruleValue) {
       return context.payload.issue.assignees.length === 0
     }
   },
   {
-    ruleName: 'assigned.pullrequest',
+    ruleName: 'assigned_pullrequest',
     webhookName: 'pull_request.assigned',
     ruleMatcher: async function (robot, context, ruleValue) {
       return context.payload.pull_request.assignees.length === 1
     }
   },
   {
-    ruleName: 'unassigned.pullrequest',
+    ruleName: 'unassigned_pullrequest',
     webhookName: 'pull_request.unassigned',
     ruleMatcher: async function (robot, context, ruleValue) {
       return context.payload.pull_request.assignees.length === 0
@@ -114,7 +114,7 @@ const AUTOMATION_COMMANDS = [
     }
   },
   {
-    ruleName: 'accepted',
+    ruleName: 'accepted_pullrequest',
     webhookName: 'pull_request_review.submitted',
     ruleMatcher: async function (robot, context, ruleValue) {
       // See https://developer.github.com/v3/activity/events/types/#pullrequestreviewevent

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,7 @@ module.exports = (robot) => {
   // Plugins that we use
   require('./slack-stuff')(robot)
   require('./move-to')(robot)
-  require('project-bot')(robot, {project: STAXLY_CONFIG.defaultProject})
+  // require('project-bot')(robot, {project: STAXLY_CONFIG.defaultProject})
   require('./automate-project-columns')(robot)
   require('probot-settings')(robot)
   // require('probot-changelog')(robot)

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ module.exports = (robot) => {
   require('./slack-api')(robot)
   require('./move-to')(robot)
   require('project-bot')(robot, {project: STAXLY_CONFIG.defaultProject})
+  require('./automate-project-columns')(robot)
   require('probot-settings')(robot)
   // require('probot-changelog')(robot)
   require('./changelog')(robot)
@@ -29,121 +30,124 @@ module.exports = (robot) => {
     robot.log('pushed code.')
   })
 
-  //
-  // React with a :table_tennis_paddle_and_ball: when a new message contains "staxly ping"
-  //
-  async function waveWhenMentioned (message, slackWeb) {
-    const {text} = message
-    if (/staxly ping/.test(text)) {
-      robot.log('ping detected')
-      robot.slackAdapter.addReaction('table_tennis_paddle_and_ball', message)
-    }
-  }
-  robot.slackAdapter.on('message', async ({payload: message, slackWeb}) => waveWhenMentioned(message, slackWeb))
-  robot.slackAdapter.on('message_changed', async ({payload: message, slackWeb}) => waveWhenMentioned({text: message.message.text, ts: message.message.ts, channel: message.channel}, slackWeb))
-
-  //
-  // When a user (not a bot) mentions a channel then add a message in that channel letting them know they were referenced
-  //
-  robot.slackAdapter.on('message', async ({payload: message, slack, slackWeb}) => {
-    let match
-
-    // Ignore any messages that the bot has posted (infinite loops)
-    if (robot.slackAdapter.isMe(message.user)) {
-      return
-    }
-
-    const channelsToMessage = []
-    while ((match = SLACK_CHANNEL_REGEXP.exec(message.text)) !== null) {
-      const channelId = match[1]
-      const channelName = match[2]
-      channelsToMessage.push({channelId, channelName})
-    }
-    for (const channelPair of channelsToMessage) {
-      const {channelId, channelName} = channelPair
-
-      // See if we have permission to post in that channel
-      robot.log(`Preparing to write to ${channelId} aka ${channelName}`)
-
-      if (channelId === message.channel) {
-        // Skip posting a message when the bot is in the same channel
-      } else if (await robot.slackAdapter.isMemberOfChannel(channelId)) {
-        // This bot is already in the channel so post there
-        robot.log(`Posting to ${channelName}`)
-        // Construct the permalink
-        const permalink = robot.slackAdapter.getMessagePermalink(message.channel, message.ts)
-        await slack.sendMessage(`This channel was mentioned in <#${message.channel}> at ${permalink}`, channelId)
-        try {
-          await robot.slackAdapter.addReaction('link', message)
-        } catch (err) {
-          // ignore if we already reacted
-        }
-      } else if (CRITSIT_PREFIX_REGEXP.test(channelName)) {
-        // Don't invite the bot to critsit channels. They are faar to common and only last for a little while
-        robot.log.trace(`Ignoring invite request to critsit channel #${channelName}`)
-      } else {
-        const sender = robot.slackAdapter.getUserById(message.user)
-        robot.log(`Asking ${sender.name} (${message.user}) to invite me to ${channelName} because I have not been invited yet`)
-        await robot.slackAdapter.sendDM(message.user, `:wave: Hello. I was unable to let <#${channelId}> know that you referred to them. If you think it might be useful to let them know, please type \`/invite @${robot.slackAdapter.getBrain().self.name} #${channelName}\` into the Slack text box below.\n\nIf not, sorry about the inconvenience. You can file an issue at https://github.com/openstax/staxly/issues/new`)
-        try {
-          await robot.slackAdapter.addReaction('robot_face', message)
-        } catch (err) {
-          // ignore if we already reacted
-        }
+  if (robot.slackAdapter) {
+    //
+    // React with a :table_tennis_paddle_and_ball: when a new message contains "staxly ping"
+    //
+    async function waveWhenMentioned (message, slackWeb) {
+      const {text} = message
+      if (/staxly ping/.test(text)) {
+        robot.log('ping detected')
+        robot.slackAdapter.addReaction('table_tennis_paddle_and_ball', message)
       }
     }
-  })
 
-  // If a slack user reacts to a message with :evergreen_tree: in a channel
-  // that is associated with a Project then automatically create a Note card
-  // with the contents of the Slack message and a link to the Slack message
-  //
-  // See https://api.slack.com/methods/conversations.history#retrieving_a_single_message
-  robot.slackAdapter.on('reaction_added', async ({payload, github, slack, slackWeb}) => {
-    const {reaction, item} = payload
-    if ((reaction === 'evergreen_tree' || reaction === 'github') && item.type === 'message') {
-      robot.log(`Noticed reaction to create a new Card`)
+    robot.slackAdapter.on('message', async ({payload: message, slackWeb}) => waveWhenMentioned(message, slackWeb))
+    robot.slackAdapter.on('message_changed', async ({payload: message, slackWeb}) => waveWhenMentioned({text: message.message.text, ts: message.message.ts, channel: message.channel}, slackWeb))
 
-      // retrieve the message
-      const theMessages = await slackWeb.channels.history({channel: item.channel, latest: item.ts, inclusive: true, count: 1})
-      robot.log('Looked up the message from history')
-      const theMessage = theMessages.messages[0]
-      const {reactions, text: messageText} = theMessage
-      robot.log.trace('Looked up the message. Checking if we already reacted to it')
+    //
+    // When a user (not a bot) mentions a channel then add a message in that channel letting them know they were referenced
+    //
+    robot.slackAdapter.on('message', async ({payload: message, slack, slackWeb}) => {
+      let match
 
-      // Check if the message already has a check mark on it
-      const linkReaction = reactions.filter((reaction) => reaction.name === 'link')[0]
-      if (linkReaction) { // Should check if we were the one to add the checkmark
-        return // already processed
+      // Ignore any messages that the bot has posted (infinite loops)
+      if (robot.slackAdapter.isMe(message.user)) {
+        return
       }
 
-      robot.log.trace('looking up to see if this channel is configured')
-      const channel = await robot.slackAdapter.getChannelById(item.channel)
-      const slackCardConfig = STAXLY_CONFIG.slackChannelsToProjects.filter(({slackChannelName}) => slackChannelName === channel.name)[0]
-      robot.log.trace('looking up to see if this channel is configured....')
-      if (channel && slackCardConfig) {
-        robot.log(`Creating Card because of reaction`)
-        // Create a new Note Card on the Project
-        const permalink = robot.slackAdapter.getMessagePermalink(channel.id, theMessage.ts)
+      const channelsToMessage = []
+      while ((match = SLACK_CHANNEL_REGEXP.exec(message.text)) !== null) {
+        const channelId = match[1]
+        const channelName = match[2]
+        channelsToMessage.push({channelId, channelName})
+      }
+      for (const channelPair of channelsToMessage) {
+        const {channelId, channelName} = channelPair
 
-        // Convert the messageText so that usernames and channelnames are not in Slack-ese (`<@U12345>`)
-        const escapedText = await robot.slackAdapter.convertTextToGitHub(messageText)
-        const noteBody = `${escapedText}
+        // See if we have permission to post in that channel
+        robot.log(`Preparing to write to ${channelId} aka ${channelName}`)
+
+        if (channelId === message.channel) {
+          // Skip posting a message when the bot is in the same channel
+        } else if (await robot.slackAdapter.isMemberOfChannel(channelId)) {
+          // This bot is already in the channel so post there
+          robot.log(`Posting to ${channelName}`)
+          // Construct the permalink
+          const permalink = robot.slackAdapter.getMessagePermalink(message.channel, message.ts)
+          await slack.sendMessage(`This channel was mentioned in <#${message.channel}> at ${permalink}`, channelId)
+          try {
+            await robot.slackAdapter.addReaction('link', message)
+          } catch (err) {
+            // ignore if we already reacted
+          }
+        } else if (CRITSIT_PREFIX_REGEXP.test(channelName)) {
+          // Don't invite the bot to critsit channels. They are faar to common and only last for a little while
+          robot.log.trace(`Ignoring invite request to critsit channel #${channelName}`)
+        } else {
+          const sender = robot.slackAdapter.getUserById(message.user)
+          robot.log(`Asking ${sender.name} (${message.user}) to invite me to ${channelName} because I have not been invited yet`)
+          await robot.slackAdapter.sendDM(message.user, `:wave: Hello. I was unable to let <#${channelId}> know that you referred to them. If you think it might be useful to let them know, please type \`/invite @${robot.slackAdapter.getBrain().self.name} #${channelName}\` into the Slack text box below.\n\nIf not, sorry about the inconvenience. You can file an issue at https://github.com/openstax/staxly/issues/new`)
+          try {
+            await robot.slackAdapter.addReaction('robot_face', message)
+          } catch (err) {
+            // ignore if we already reacted
+          }
+        }
+      }
+    })
+
+    // If a slack user reacts to a message with :evergreen_tree: in a channel
+    // that is associated with a Project then automatically create a Note card
+    // with the contents of the Slack message and a link to the Slack message
+    //
+    // See https://api.slack.com/methods/conversations.history#retrieving_a_single_message
+    robot.slackAdapter.on('reaction_added', async ({payload, github, slack, slackWeb}) => {
+      const {reaction, item} = payload
+      if ((reaction === 'evergreen_tree' || reaction === 'github') && item.type === 'message') {
+        robot.log(`Noticed reaction to create a new Card`)
+
+        // retrieve the message
+        const theMessages = await slackWeb.channels.history({channel: item.channel, latest: item.ts, inclusive: true, count: 1})
+        robot.log('Looked up the message from history')
+        const theMessage = theMessages.messages[0]
+        const {reactions, text: messageText} = theMessage
+        robot.log.trace('Looked up the message. Checking if we already reacted to it')
+
+        // Check if the message already has a check mark on it
+        const linkReaction = reactions.filter((reaction) => reaction.name === 'link')[0]
+        if (linkReaction) { // Should check if we were the one to add the checkmark
+          return // already processed
+        }
+
+        robot.log.trace('looking up to see if this channel is configured')
+        const channel = await robot.slackAdapter.getChannelById(item.channel)
+        const slackCardConfig = STAXLY_CONFIG.slackChannelsToProjects.filter(({slackChannelName}) => slackChannelName === channel.name)[0]
+        robot.log.trace('looking up to see if this channel is configured....')
+        if (channel && slackCardConfig) {
+          robot.log(`Creating Card because of reaction`)
+          // Create a new Note Card on the Project
+          const permalink = robot.slackAdapter.getMessagePermalink(channel.id, theMessage.ts)
+
+          // Convert the messageText so that usernames and channelnames are not in Slack-ese (`<@U12345>`)
+          const escapedText = await robot.slackAdapter.convertTextToGitHub(messageText)
+          const noteBody = `${escapedText}
 
 [Slack Link](${permalink})`
 
-        const project = (await github.projects.getOrgProjects({org: slackCardConfig.githubProjectOrg})).data.filter(({number}) => slackCardConfig.githubProjectNumber)[0]
-        const projectColumn = (await github.projects.getProjectColumns({project_id: project.id})).data[0]
-        await github.projects.createProjectCard({column_id: projectColumn.id, note: noteBody})
+          const project = (await github.projects.getOrgProjects({org: slackCardConfig.githubProjectOrg})).data.filter(({number}) => slackCardConfig.githubProjectNumber)[0]
+          const projectColumn = (await github.projects.getProjectColumns({project_id: project.id})).data[0]
+          await github.projects.createProjectCard({column_id: projectColumn.id, note: noteBody})
 
-        robot.slackAdapter.addReaction('link', {channel: channel.id, ts: theMessage.ts})
-      } else {
-        robot.log.trace('channel is not configured for reactions')
-        const channel = await robot.slackAdapter.getChannelById(item.channel)
-        await robot.slackAdapter.sendDM(theMessage.user, `:wave: I noticed you reacted to a message with a :${reaction}: indicating that I should create a Card. Unfortunately #${channel.name} is not linked to a Project so I was unable to automatically create a Card. Please file an issue at https://github.com/openstax/staxly/issues/new and we will get that fixed right up!`)
+          robot.slackAdapter.addReaction('link', {channel: channel.id, ts: theMessage.ts})
+        } else {
+          robot.log.trace('channel is not configured for reactions')
+          const channel = await robot.slackAdapter.getChannelById(item.channel)
+          await robot.slackAdapter.sendDM(theMessage.user, `:wave: I noticed you reacted to a message with a :${reaction}: indicating that I should create a Card. Unfortunately #${channel.name} is not linked to a Project so I was unable to automatically create a Card. Please file an issue at https://github.com/openstax/staxly/issues/new and we will get that fixed right up!`)
+        }
       }
-    }
-  })
+    })
+  }
 
   // // If someone submits a Pull Request check if it has a reviewer
   // function getSlackUserByGithubIdOrNull (githubId) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,10 @@
-const STAXLY_CONFIG = require('../config.json')
-
 module.exports = (robot) => {
   robot.events.setMaxListeners(100) // Since we use multiple plugins
 
   // Plugins that we use
   require('./slack-stuff')(robot)
   require('./move-to')(robot)
-  // require('project-bot')(robot, {project: STAXLY_CONFIG.defaultProject})
+  // require('project-bot')(robot)
   require('./automate-project-columns')(robot)
   require('probot-settings')(robot)
   // require('probot-changelog')(robot)

--- a/yarn.lock
+++ b/yarn.lock
@@ -991,6 +991,15 @@ commander@^2.11.0, commander@^2.12.2:
   version "2.13.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.13.0.tgz#6964bca67685df7c1f1430c584f07d7597885b9c"
 
+commonmark@^0.28.1:
+  version "0.28.1"
+  resolved "https://registry.yarnpkg.com/commonmark/-/commonmark-0.28.1.tgz#06eab8d52338b839fa1a2d75af0085eed1b1beae"
+  dependencies:
+    entities "~ 1.1.1"
+    mdurl "~ 1.0.1"
+    minimist "~ 1.2.0"
+    string.prototype.repeat "^0.2.0"
+
 component-emitter@^1.2.0, component-emitter@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.2.1.tgz#137918d6d78283f7df7a6b7c5a63e140e69425e6"
@@ -1356,7 +1365,7 @@ encoding@^0.1.11:
   dependencies:
     iconv-lite "~0.4.13"
 
-entities@^1.1.1, entities@~1.1.1:
+entities@^1.1.1, "entities@~ 1.1.1", entities@~1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
@@ -3780,6 +3789,10 @@ md5@^2.2.1:
     crypt "~0.0.1"
     is-buffer "~1.1.1"
 
+"mdurl@~ 1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-1.0.1.tgz#fe85b2ec75a59037f2adfec100fd6c601761152e"
+
 media-typer@0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/media-typer/-/media-typer-0.3.0.tgz#8710d7af0aa626f8fffa1ce00168545263255748"
@@ -3884,7 +3897,7 @@ minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
 
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0:
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.2.0, "minimist@~ 1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
@@ -5390,6 +5403,10 @@ string-width@^2.0.0, string-width@^2.1.0, string-width@^2.1.1:
     is-fullwidth-code-point "^2.0.0"
     strip-ansi "^4.0.0"
 
+string.prototype.repeat@^0.2.0:
+  version "0.2.0"
+  resolved "https://registry.yarnpkg.com/string.prototype.repeat/-/string.prototype.repeat-0.2.0.tgz#aba36de08dcee6a5a337d49b2ea1da1b28fc0ecf"
+
 string_decoder@~0.10.x:
   version "0.10.31"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-0.10.31.tgz#62e203bc41766c6c28c9fc84301dab1c5310fa94"
@@ -5674,7 +5691,7 @@ unfurl.js@^1.1.6:
   dependencies:
     ejs "^2.5.7"
     jsdom "^11.3.0"
-    probot "^6.0.0"
+    probot "^2.0.0"
     probot-attachments "github:probot/attachments"
     unfurl.js "^1.1.6"
 


### PR DESCRIPTION
It would be useful to have logic for moving Issues in a Project ( see #21 )

# Screencap

![automatic-project-columns](https://user-images.githubusercontent.com/253202/37872089-ad7d21ea-2fcd-11e8-81ba-7f3977c102cf.gif)


The type of rules outlined in there are:

- [x] `new_issue` : When an Issue is created (optionally, a space-separated set of repo names)
- [x] `new_pullrequest` : When a Pull Request is created (optionally, a space-separated set of repo names)
- [x] `assigned_to_issue`: When an Issue is assigned to a specific user
- [x] `assigned_issue`: When an Issue is assigned to a user (but was not before)
- [x] `unassigned_issue`: When an Issue is no longer assigned to a user
- [x] `assigned_pullrequest`: When a Pull Request is assigned to a user (but was not before)
- [x] `unassigned_pullrequest`: When a Pull Request is no longer assigned to a user
- [x] `reopened_issue`: When an Issue is reopened
- [x] `reopened_pullrequest`: When a Pull Request is reopened
- [x] `added_reviewer`: (optional username or array of usernames that need to be added)
- [x] `accepted_pullrequest`: When at least one Reviewer Accepted, and there are no Rejections on a Pull request
- [x] `merged_pullrequest`: When a Pull Request is merged
- [x] `closed_pullrequest`: When a Pull Request is closed
- [x] `added_label`: (has one argument, the string representing the name of the label)
- [x] `removed_label`: (has one argument, the string representing the name of the label)
- [x] `closed_issue`: When an Issue is closed
- [x] `edited_issue`
- [x] `milestoned_issue`
- [x] `demilestoned_issue`
- More are possible, like `stale`, `included-in-release`, or others

# How to Create Rules

To create an Automation Rule, create a Card in a Project like this:

```md
###### Automation Rules

<!-- Documentation: https://github.com/philschatz/probot-project -->

- `assigned_issue`
- `added_label` wontfix
- `new_pullrequest` foo-bar test
- `closed_issue`
```