### PR TITLE
add route to see Project History

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ SLACK_BOT_TOKEN=
 
 # Number that represents which GitHub install to use when Slack is responding to messages
 SLACK_GITHUB_INSTALL_ID=
+
+# the 'secret' part of the path to get updates on Project Cards moving and being edited
+SECRET_PROJECT_EVENTS_PATH="some-obscure-name"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,14 @@ To move an Issue, create a Comment on an Issue that begins with `move-to {reposi
 <a href="https://user-images.githubusercontent.com/253202/36949462-aee82baa-1fb6-11e8-9920-24ad629532ec.gif"><img width="500" alt="project-issues" src="https://user-images.githubusercontent.com/253202/36949462-aee82baa-1fb6-11e8-9920-24ad629532ec.gif"/></a>
 
 
-### Channel link-back
+### Project Events Export ([#51](https://github.com/openstax/staxly/pull/51))
+
+There is a secret URL to get a CSV or a JSON file of the history of Cards being created and moved which is useful for generating reports.
+
+The URL format is `/project-events/{secret}/json` and `/project-events/{secret}/csv`.
+
+
+### Slack Channel link-back
 
 When someone mentions a channel in a message, that channel gets a link back to the original message.
 This is useful for notifying multiple groups, or casually asking for help.

--- a/app.json
+++ b/app.json
@@ -20,6 +20,10 @@
       "description": "the private key you downloaded when creating the GitHub App. See probot Install docs",
       "required": true
     },
+    "SECRET_PROJECT_EVENTS_PATH": {
+      "description": "the 'secret' part of the path to get updates on Project Cards moving and being edited",
+      "required": true
+    },
     "SENTRY_DSN": {
       "description": "URL to report sentry errors to",
       "required": false

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "autolabeler": "github:probot/autolabeler",
     "commonmark": "^0.28.1",
     "first-pr-merge": "github:behaviorbot/first-pr-merge",
+    "json-2-csv": "^2.2.0",
     "new-issue-welcome": "github:behaviorbot/new-issue-welcome",
     "new-pr-welcome": "github:behaviorbot/new-pr-welcome",
     "nodemon": "^1.14.11",

--- a/src/index.js
+++ b/src/index.js
@@ -17,6 +17,7 @@ module.exports = (robot) => {
   // require('probot-app-todos')(robot)
   require('release-notifier')(robot)
   require('wip-bot')(robot)
+  require('./project-events')(robot)
 
   console.log('Yay, the app was loaded!')
 

--- a/src/project-events.js
+++ b/src/project-events.js
@@ -18,7 +18,12 @@ module.exports = async (robot) => {
       res.send(csv)
     }, {
       prependHeader: true,
-      delimiter: {wrap: '"'}
+      delimiter: {
+        field: ',',
+        array: ';',
+        wrap: '"',
+        eol: '\n'
+      }
     })
   })
 

--- a/src/project-events.js
+++ b/src/project-events.js
@@ -1,0 +1,62 @@
+const {json2csv} = require('json-2-csv')
+
+// Output the 1000 most-recent events related to Projects and Cards
+
+const MAX_LENGTH = 1000
+const MOST_RECENT = []
+
+const COLUMN_CACHE = {}
+const PROJECT_CACHE = {}
+
+module.exports = async (robot) => {
+  const app = robot.route(`/project-events/${process.env['SECRET_PROJECT_EVENTS_PATH']}`)
+  app.get('/json', (req, res) => {
+    res.json(MOST_RECENT)
+  })
+  app.get('/csv', (req, res) => {
+    json2csv(MOST_RECENT, (err, csv) => {
+      res.send(csv)
+    }, {
+      prependHeader: true,
+      delimiter: {wrap: '"'}
+    })
+  })
+
+  robot.on('project_card', async (context) => {
+    const data = context.payload.project_card
+    const column = COLUMN_CACHE[data.column_url] || (await context.github.request({method: 'GET', url: data.column_url, headers: {'accept': 'application/vnd.github.inertia-preview+json'}})).data
+    const project = PROJECT_CACHE[column.project_url] || (await context.github.request({method: 'GET', url: column.project_url, headers: {'accept': 'application/vnd.github.inertia-preview+json'}})).data
+
+    // Update the cache
+    COLUMN_CACHE[data.column_url] = column
+    PROJECT_CACHE[column.project_url] = project
+
+    const entry = {
+      eventName: 'project_card',
+      action: context.payload.action,
+      sender: context.payload.sender.login,
+      columnId: column.id,
+      columnName: column.name,
+      projectId: project.id,
+      projectName: project.name,
+      id: data.id,
+      note: data.note,
+      contentUrl: data.content_url,
+      creator: data.creator.login,
+      createdAt: data.created_at,
+      updatedAt: data.updated_at
+    }
+    if (context.payload.repository) {
+      entry.repositoryId = context.payload.repository.id
+      entry.repositoryName = context.payload.repository.full_name
+    }
+    if (context.payload.organization) {
+      entry.organization = context.payload.organization.login
+    }
+    MOST_RECENT.push(entry)
+    if (MOST_RECENT.length > MAX_LENGTH) {
+      MOST_RECENT.shift(1)
+    }
+  })
+
+}

--- a/src/project-events.js
+++ b/src/project-events.js
@@ -15,7 +15,12 @@ module.exports = async (robot) => {
   })
   app.get('/csv', (req, res) => {
     json2csv(MOST_RECENT, (err, csv) => {
-      res.send(csv)
+      if (err) {
+        robot.log.error(err.message)
+        res.status(500).send('CSV Parsing Error')
+      } else {
+        res.send(csv)
+      }
     }, {
       prependHeader: true,
       delimiter: {
@@ -63,5 +68,4 @@ module.exports = async (robot) => {
       MOST_RECENT.shift(1)
     }
   })
-
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -659,6 +659,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+bluebird@3.5.1:
+  version "3.5.1"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.5.1.tgz#d9551f9de98f1fcda1e683d17ee91a0602ee2eb9"
+
 body-parser@1.18.2:
   version "1.18.2"
   resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.2.tgz#87678a19d84b47d859b83199bd59bce222b10454"
@@ -1286,6 +1290,10 @@ detect-newline@^2.1.0:
 diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
+
+doc-path@1.2.1:
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/doc-path/-/doc-path-1.2.1.tgz#2068ec83c1d967bea51ba99263e479d6dd1d17a3"
 
 doctrine@1.5.0:
   version "1.5.0"
@@ -3554,6 +3562,14 @@ jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
 
+json-2-csv@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json-2-csv/-/json-2-csv-2.2.0.tgz#5de1e738c9cb47cbca7770cd15ce5121d6f26dbb"
+  dependencies:
+    bluebird "3.5.1"
+    doc-path "1.2.1"
+    underscore "1.8.3"
+
 json-buffer@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.0.tgz#5b1f397afc75d677bde8bcfc0e47e1f9a3d9a898"
@@ -5818,6 +5834,10 @@ undefsafe@^2.0.1:
   resolved "https://registry.yarnpkg.com/undefsafe/-/undefsafe-2.0.1.tgz#03b2f2a16c94556e14b2edef326cd66aaf82707a"
   dependencies:
     debug "^2.2.0"
+
+underscore@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
 
 unfurl.js@^1.1.6:
   version "1.1.6"


### PR DESCRIPTION
This adds the following endpoints which can be used for generating reports:

- `/project-events/{secret}/json`
- `/project-events/{secret}/csv`

The data contains the following fields that are extracted from the [Project Card Event](https://developer.github.com/v3/activity/events/types/#projectcardevent):

- `eventName` : always `project_card`
- `action` : One of `created`, `edited`, `converted`, `moved`, `deleted`
- `sender` : Username that initiated the change (sometimes a bot)
- `columnId` : Unique ID of the Column
- `columnName` : Name of the Column  that this card is now in (can be renamed)
- `projectId` : Unique ID of the Project
- `projectName` : Name of the Project that this card is in (can be renamed)
- `id` : unique ID of the Card
- `note` **(optional)** : Contents of the card (if it does not link to an Issue or Pull Request)
- `contentUrl` **(optional)** : Link to the Issue or Pull Request or Project that this card represents
- `createdAt` : Time when the Card was created
- `updatedAt` : Time when the Card was updated
- `organization` **(optional)** : Either `openstax` or `Connexions`
- `repositoryName` **(optional)** : Only applies to Projects on a specific repository
- `repositoryId`

Here is an example CSV snippet:

```csv
"eventName","action","sender","columnId","columnName","projectId","projectName","id","note","contentUrl","creator","createdAt","updatedAt","repositoryId","repositoryName" 
"project_card","moved","philschatz","2202274","In progress","1292562","Sprint Board","8474648","","https://api.github.com/repos/philschatz/test/issues/63","staxly-dev[bot]","2018-03-27T02:48:55Z","2018-04-06T18:33:03Z","88528849","philschatz/test"
```