### PR TITLE
track versions in release cards

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ module.exports = (robot) => {
   require('./merge-bases')(robot)
   require('./link-issues')(robot)
   require('./auto-merge')(robot)
+  require('./track-versions')(robot)
 
   // Addons that are noisy during tests
   if (!IGNORE_FOR_TESTING) {

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -20,15 +20,18 @@ const updateReleaseCards = (logger, context, masterRepo, versionKey, version) =>
   const [owner, repo] = masterRepo.split('/')
 
   const processIssues = ({data}) => {
-    return Promise.all(data.map(issue => {
-      logger.info(`updating version "${versionKey}" in ${masterRepo}#${issue.number} to "${version}"`)
-      return context.github.issues.update({
-        owner,
-        repo,
-        issue_number: issue.number,
-        body: setVersion(issue.body, versionKey, version)
+    return Promise.all(data
+      .filter(issue => !issue.labels.map(({name}) => name).includes('locked'))
+      .map(issue => {
+        logger.info(`updating version "${versionKey}" in ${masterRepo}#${issue.number} to "${version}"`)
+        return context.github.issues.update({
+          owner,
+          repo,
+          issue_number: issue.number,
+          body: setVersion(issue.body, versionKey, version)
+        })
       })
-    }))
+    )
   }
 
   return context.github.paginate(

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -51,7 +51,7 @@ module.exports = (robot) => {
     const branch = payload.ref.replace(/^refs\/heads\//, '')
     const repo = payload.repository.full_name
     const versionKey = `${repo} (sha)`
-    const version = payload.head.substring(0, 7)
+    const version = payload.after.substring(0, 7)
 
     if (branch !== 'master') {
       return

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -1,0 +1,66 @@
+const {setVersion} = require('./utils/versionsBlock')
+
+const releaseCardRepos = {
+  'testowner/testrepo': [
+    'testowner/testrepo',
+    'testowner/testotherrepo'
+  ],
+  'openstax/unified': [
+    'openstax/rex-web',
+    'openstax/highlights-api',
+    'openstax/open-search',
+    'openstax/unified-deployment',
+  ],
+  'TomWoodward/testing-stuff': [
+    'TomWoodward/testing-stuff'
+  ]
+}
+
+const updateReleaseCards = (logger, context, masterRepo, versionKey, version) => {
+  const [owner, repo] = masterRepo.split('/');
+
+  const processIssues = ({data}) => {
+    return Promise.all(data.map(issue => {
+      logger.info(`updating version "${versionKey}" in ${masterRepo}#${issue.number} to "${version}"`)
+      return context.github.issues.update({
+        owner,
+        repo,
+        issue_number: issue.number,
+        body: setVersion(issue.body, versionKey, version)
+      })
+    }))
+  };
+
+  return context.github.paginate(
+    context.github.issues.listForRepo.endpoint.merge({
+      owner,
+      repo,
+      labels: 'release',
+      state: 'open'
+    }),
+    processIssues
+  )
+    .then(pagePromises => Promise.all(pagePromises))
+};
+
+module.exports = (robot) => {
+  const logger = robot.log.child({name: 'track-versions'})
+
+  robot.on(['push'], (context) => {
+    const {payload} = context
+    const branch = payload.ref.replace(/^refs\/heads\//, '')
+    const repo = payload.repository.full_name
+    const versionKey = `${repo} (sha)`
+    const version = payload.head.substring(0, 7);
+
+    if (branch !== 'master') {
+      return;
+    }
+
+    return Promise.all(
+      Object.entries(releaseCardRepos)
+        .filter(([, childRepos]) => childRepos.includes(repo))
+        .map(([masterRepo]) => updateReleaseCards(logger, context, masterRepo, versionKey, version))
+    );
+  });
+}

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -9,7 +9,7 @@ const releaseCardRepos = {
     'openstax/rex-web',
     'openstax/highlights-api',
     'openstax/open-search',
-    'openstax/unified-deployment',
+    'openstax/unified-deployment'
   ],
   'TomWoodward/testing-stuff': [
     'TomWoodward/testing-stuff'
@@ -17,7 +17,7 @@ const releaseCardRepos = {
 }
 
 const updateReleaseCards = (logger, context, masterRepo, versionKey, version) => {
-  const [owner, repo] = masterRepo.split('/');
+  const [owner, repo] = masterRepo.split('/')
 
   const processIssues = ({data}) => {
     return Promise.all(data.map(issue => {
@@ -29,7 +29,7 @@ const updateReleaseCards = (logger, context, masterRepo, versionKey, version) =>
         body: setVersion(issue.body, versionKey, version)
       })
     }))
-  };
+  }
 
   return context.github.paginate(
     context.github.issues.listForRepo.endpoint.merge({
@@ -41,7 +41,7 @@ const updateReleaseCards = (logger, context, masterRepo, versionKey, version) =>
     processIssues
   )
     .then(pagePromises => Promise.all(pagePromises))
-};
+}
 
 module.exports = (robot) => {
   const logger = robot.log.child({name: 'track-versions'})
@@ -51,16 +51,16 @@ module.exports = (robot) => {
     const branch = payload.ref.replace(/^refs\/heads\//, '')
     const repo = payload.repository.full_name
     const versionKey = `${repo} (sha)`
-    const version = payload.head.substring(0, 7);
+    const version = payload.head.substring(0, 7)
 
     if (branch !== 'master') {
-      return;
+      return
     }
 
     return Promise.all(
       Object.entries(releaseCardRepos)
         .filter(([, childRepos]) => childRepos.includes(repo))
         .map(([masterRepo]) => updateReleaseCards(logger, context, masterRepo, versionKey, version))
-    );
-  });
+    )
+  })
 }

--- a/src/utils/connectedPRRegexes.js
+++ b/src/utils/connectedPRRegexes.js
@@ -5,8 +5,6 @@ const {
 
 const anyLink = `((${githubRef})|(${githubPullRequestLink})|(${zenhubLink}))`
 
-const listPrefix = '\\n\\- \\[( |x)\\] '
-
 const anyLinkGroups = [
   githubRefGroups,
   githubPullRequestLinkGroups,
@@ -14,7 +12,6 @@ const anyLinkGroups = [
 ]
 
 module.exports = {
-  listPrefix,
   anyLinkGroups,
   anyLink
 }

--- a/src/utils/getPRBlock.js
+++ b/src/utils/getPRBlock.js
@@ -1,5 +1,5 @@
-const { whitespace, beginningOfStringOrNewline } = require('./regexes')
-const { listPrefix, anyLink } = require('./connectedPRRegexes')
+const { whitespace, beginningOfStringOrNewline, listPrefix } = require('./regexes')
+const { anyLink } = require('./connectedPRRegexes')
 
 const prBlockRegex = `${beginningOfStringOrNewline}(?<block>#* ?\\*{0,2}pull requests:?\\*{0,2}:?(${whitespace}*${listPrefix}${anyLink})*)`
 

--- a/src/utils/prIsReadyForAutoMerge.js
+++ b/src/utils/prIsReadyForAutoMerge.js
@@ -14,17 +14,17 @@ module.exports = async (github, pullRequest, optionalIssue) => {
     return false
   }
 
-  const loadIssue = async() => {
+  const loadIssue = async () => {
     const linkedIssueParams = getConnectedIssueForPR(pullRequest)
 
     if (!linkedIssueParams) {
-      return null;
+      return null
     }
 
-    const response = await github.issues.get(linkedIssueParams);
+    const response = await github.issues.get(linkedIssueParams)
 
     if (response && response.data) {
-      return response.data;
+      return response.data
     }
   }
 

--- a/src/utils/regexes.js
+++ b/src/utils/regexes.js
@@ -7,6 +7,8 @@ const beginningOfStringOrNewline = `^([^${newlineCharacters}]+${newline}+)*[${ne
 const beginningOfStringOrWhitespace = `^([^${whitespaceCharacters}]+[${whitespaceCharacters}]+)*[${whitespaceCharacters}]*`
 const endOfStringOrWhitespace = `([${whitespaceCharacters}]+[^${whitespaceCharacters}]+)*[${whitespaceCharacters}]*$`
 
+const listPrefix = '\\n\\- \\[( |x)\\] '
+
 /* eslint-disable-next-line */
 const githubRefGroups = '(?<owner>[a-z\-]+)\/(?<repo>[a-z\-]+)#(?<number>[0-9]+)'
 /* eslint-disable-next-line */
@@ -24,17 +26,18 @@ const githubPullRequestLink = 'https:\/\/github.com\/[a-z\-]+\/[a-z\-]+\/pulls\/
 const zenhubLink = 'https:\/\/app.zenhub.com\/workspaces\/[0-9a-z\-]+\/issues\/[a-z\-]+\/[a-z\-]+\/[0-9]+'
 
 module.exports = {
-  whitespace,
-  newline,
-  newlineCharacters,
   beginningOfStringOrNewline,
   beginningOfStringOrWhitespace,
   endOfStringOrWhitespace,
-  githubRefGroups,
   githubIssueLinkGroups,
-  githubPullRequestLinkGroups,
-  zenhubLinkGroups,
-  githubRef,
   githubPullRequestLink,
-  zenhubLink
+  githubPullRequestLinkGroups,
+  githubRef,
+  githubRefGroups,
+  listPrefix,
+  newline,
+  newlineCharacters,
+  whitespace,
+  zenhubLink,
+  zenhubLinkGroups
 }

--- a/src/utils/removeConnectedPRFromIssue.js
+++ b/src/utils/removeConnectedPRFromIssue.js
@@ -1,4 +1,5 @@
-const {anyLink, listPrefix, anyLinkGroups} = require('./connectedPRRegexes')
+const {listPrefix} = require('./regexes')
+const {anyLink, anyLinkGroups} = require('./connectedPRRegexes')
 const getPRBlock = require('./getPRBlock')
 
 /*

--- a/src/utils/versionsBlock.js
+++ b/src/utils/versionsBlock.js
@@ -2,7 +2,7 @@ const { whitespace, beginningOfStringOrNewline, newline, newlineCharacters } = r
 
 const blockItem = `${newline}+${whitespace}*\\- (?<name>[^:]+): (?<version>[^${newlineCharacters}]+)`
 const blockItems = `(${blockItem})+`
-const versionBlockRegex = `${beginningOfStringOrNewline}(?<block>#* ?\\*{0,2}versions:?\\*{0,2}:?${blockItems}`
+const versionBlockRegex = `${beginningOfStringOrNewline}(?<block>#* ?\\*{0,2}versions:?\\*{0,2}:?${blockItems})`
 
 const getVersionsBlock = (body) => {
   const blockMatch = body.match(new RegExp(versionBlockRegex, 'i'))
@@ -21,7 +21,7 @@ const getVersions = (body) => {
     .reduce((result, item) => ({...result, [item.name]: item.version}), {})
 }
 
-const getItemVersion = (body, itemName) => {
+const getVersion = (body, itemName) => {
   const versions = getVersions(body)
 
   if (!versions) {
@@ -31,27 +31,27 @@ const getItemVersion = (body, itemName) => {
   return versions[itemName]
 }
 
-const setBlockVersions = (body, versions) => {
+const setVersions = (body, versions) => {
   const versionsText = getVersionsBlock(body)
-  const itemsText = versionsText && versionsText.match(new RegExp(blockItems, 'i'))
+  const itemsText = versionsText && versionsText.match(new RegExp(blockItems, 'i'))[0]
 
   const newItemsText = Object.entries(versions).reduce((result, [name, version]) =>
     result + `\n- ${name}: ${version}`
-    , '')
+  , '')
 
   return itemsText
     ? body.replace(itemsText, newItemsText)
     : body + '\n\nversions:' + newItemsText
 }
 
-const setItemVersion = (body, itemName, version) => {
+const setVersion = (body, itemName, version) => {
   const versions = getVersions(body) || {}
-  return setBlockVersions(body, {...versions, [itemName]: version})
+  return setVersions(body, {...versions, [itemName]: version})
 }
 
 module.exports = {
   getVersions,
-  getItemVersion,
-  setBlockVersions,
-  setItemVersion
+  getVersion,
+  setVersions,
+  setVersion
 }

--- a/src/utils/versionsBlock.js
+++ b/src/utils/versionsBlock.js
@@ -1,0 +1,57 @@
+const { whitespace, beginningOfStringOrNewline, newline, newlineCharacters } = require('./regexes')
+
+const blockItem = `${newline}+${whitespace}*\\- (?<name>[^:]+): (?<version>[^${newlineCharacters}]+)`
+const blockItems = `(${blockItem})+`
+const versionBlockRegex = `${beginningOfStringOrNewline}(?<block>#* ?\\*{0,2}versions:?\\*{0,2}:?${blockItems}`
+
+const getVersionsBlock = (body) => {
+  const blockMatch = body.match(new RegExp(versionBlockRegex, 'i'))
+  return blockMatch && blockMatch.groups.block
+}
+
+const getVersions = (body) => {
+  const versionsText = getVersionsBlock(body)
+
+  if (!versionsText) {
+    return null
+  }
+
+  return versionsText.match(new RegExp(blockItem, 'gi'))
+    .map(itemText => itemText.match(new RegExp(blockItem, 'i')).groups)
+    .reduce((result, item) => ({...result, [item.name]: item.version}), {})
+}
+
+const getItemVersion = (body, itemName) => {
+  const versions = getVersions(body)
+
+  if (!versions) {
+    return null
+  }
+
+  return versions[itemName]
+}
+
+const setBlockVersions = (body, versions) => {
+  const versionsText = getVersionsBlock(body)
+  const itemsText = versionsText && versionsText.match(new RegExp(blockItems, 'i'))
+
+  const newItemsText = Object.entries(versions).reduce((result, [name, version]) =>
+    result + `\n- ${name}: ${version}`
+    , '')
+
+  return itemsText
+    ? body.replace(itemsText, newItemsText)
+    : body + '\n\nversions:' + newItemsText
+}
+
+const setItemVersion = (body, itemName, version) => {
+  const versions = getVersions(body) || {}
+  return setBlockVersions(body, {...versions, [itemName]: version})
+}
+
+module.exports = {
+  getVersions,
+  getItemVersion,
+  setBlockVersions,
+  setItemVersion
+}

--- a/src/utils/versionsBlock.js
+++ b/src/utils/versionsBlock.js
@@ -18,7 +18,7 @@ const getVersions = (body, filter = () => true) => {
 
   return versionsText.match(new RegExp(blockItem, 'gi'))
     .map(itemText => {
-      const {groups} = itemText.match(new RegExp(blockItem, 'i'));
+      const {groups} = itemText.match(new RegExp(blockItem, 'i'))
       return {...groups, locked: !!groups.locked}
     })
     .filter(filter)
@@ -37,13 +37,13 @@ const getVersion = (body, itemName) => {
 
 const setVersions = (body, versions) => {
   const lockedVersions = getVersions(body, item => item.locked) || {}
-  const newVersions = {...versions, ...lockedVersions};
+  const newVersions = {...versions, ...lockedVersions}
   const versionsText = getVersionsBlock(body)
   const itemsText = versionsText && versionsText.match(new RegExp(blockItems, 'i'))[0]
 
   const newItemsText = Object.entries(newVersions).reduce((result, [name, version]) =>
     result + `\n- ${name}: ${version}`
-  , '')
+    , '')
 
   return itemsText
     ? body.replace(itemsText, newItemsText)
@@ -55,7 +55,7 @@ const setVersion = (body, itemName, version) => {
 
   return setVersions(body, {
     ...versions,
-    [itemName]: version,
+    [itemName]: version
   })
 }
 

--- a/test/merge-bases.test.js
+++ b/test/merge-bases.test.js
@@ -1,5 +1,5 @@
 const nock = require('nock')
-const myProbotApp = require('..')
+const mergeBases = require('../src/merge-bases')
 const { createProbot } = require('probot')
 
 describe('My Probot app', () => {
@@ -8,7 +8,7 @@ describe('My Probot app', () => {
   beforeEach(() => {
     nock.disableNetConnect()
     app = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
-    app.load(myProbotApp)
+    app.load(mergeBases)
   })
 
   test('updates branch', async () => {

--- a/test/track-versions.test.js
+++ b/test/track-versions.test.js
@@ -19,14 +19,14 @@ describe('track-versions', () => {
   test('updates issues', async () => {
     nock('https://api.github.com')
       .get('/repos/testowner/testrepo/issues')
-      .query({"labels":"release","state":"open"})
+      .query({'labels': 'release', 'state': 'open'})
       .reply(200, [{number: 5, body: 'body'}])
 
     nock('https://api.github.com')
       .patch('/repos/testowner/testrepo/issues/5', request => request.body === 'newbody')
       .reply(200, {number: 5})
 
-    setVersion.mockReturnValue('newbody');
+    setVersion.mockReturnValue('newbody')
 
     await app.receive({
       name: 'push',
@@ -42,8 +42,8 @@ describe('track-versions', () => {
         }
       }
     })
-    
-    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testrepo (sha)', 'asdfasd');
+
+    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testrepo (sha)', 'asdfasd')
 
     expect(nock.isDone()).toBe(true)
   })
@@ -51,14 +51,14 @@ describe('track-versions', () => {
   test('updates issues from other repo', async () => {
     nock('https://api.github.com')
       .get('/repos/testowner/testrepo/issues')
-      .query({"labels":"release","state":"open"})
+      .query({'labels': 'release', 'state': 'open'})
       .reply(200, [{number: 5, body: 'body'}])
 
     nock('https://api.github.com')
       .patch('/repos/testowner/testrepo/issues/5', request => request.body === 'newbody')
       .reply(200, {number: 5})
 
-    setVersion.mockReturnValue('newbody');
+    setVersion.mockReturnValue('newbody')
 
     await app.receive({
       name: 'push',
@@ -74,8 +74,8 @@ describe('track-versions', () => {
         }
       }
     })
-    
-    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testotherrepo (sha)', 'asdfasd');
+
+    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testotherrepo (sha)', 'asdfasd')
 
     expect(nock.isDone()).toBe(true)
   })

--- a/test/track-versions.test.js
+++ b/test/track-versions.test.js
@@ -1,0 +1,106 @@
+const nock = require('nock')
+const trackVersions = require('../src/track-versions')
+const { createProbot } = require('probot')
+jest.mock('../src/utils/versionsBlock', () => ({
+  setVersion: jest.fn()
+}))
+
+const {setVersion} = require('../src/utils/versionsBlock')
+
+describe('track-versions', () => {
+  let app
+
+  beforeEach(() => {
+    nock.disableNetConnect()
+    app = createProbot({ id: 1, cert: 'test', githubToken: 'test' })
+    app.load(trackVersions)
+  })
+
+  test('updates issues', async () => {
+    nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/issues')
+      .query({"labels":"release","state":"open"})
+      .reply(200, [{number: 5, body: 'body'}])
+
+    nock('https://api.github.com')
+      .patch('/repos/testowner/testrepo/issues/5', request => request.body === 'newbody')
+      .reply(200, {number: 5})
+
+    setVersion.mockReturnValue('newbody');
+
+    await app.receive({
+      name: 'push',
+      payload: {
+        ref: 'refs/heads/master',
+        head: 'asdfasdfasdfasdfasdf',
+        repository: {
+          name: 'testrepo',
+          full_name: 'testowner/testrepo',
+          owner: {
+            name: 'testowner'
+          }
+        }
+      }
+    })
+    
+    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testrepo (sha)', 'asdfasd');
+
+    expect(nock.isDone()).toBe(true)
+  })
+
+  test('updates issues from other repo', async () => {
+    nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/issues')
+      .query({"labels":"release","state":"open"})
+      .reply(200, [{number: 5, body: 'body'}])
+
+    nock('https://api.github.com')
+      .patch('/repos/testowner/testrepo/issues/5', request => request.body === 'newbody')
+      .reply(200, {number: 5})
+
+    setVersion.mockReturnValue('newbody');
+
+    await app.receive({
+      name: 'push',
+      payload: {
+        ref: 'refs/heads/master',
+        head: 'asdfasdfasdfasdfasdf',
+        repository: {
+          name: 'testotherrepo',
+          full_name: 'testowner/testotherrepo',
+          owner: {
+            name: 'testowner'
+          }
+        }
+      }
+    })
+    
+    expect(setVersion).toHaveBeenCalledWith('body', 'testowner/testotherrepo (sha)', 'asdfasd');
+
+    expect(nock.isDone()).toBe(true)
+  })
+
+  test('noops outside whitelist', async () => {
+    await app.receive({
+      name: 'push',
+      payload: {
+        ref: 'refs/heads/master',
+        head: 'asdfasdfasdfasdfasdf',
+        repository: {
+          full_name: 'testowner/randomrepo',
+          name: 'randomrepo',
+          owner: {
+            name: 'testowner'
+          }
+        }
+      }
+    })
+
+    expect(nock.isDone()).toBe(true)
+  })
+
+  afterEach(() => {
+    nock.cleanAll()
+    nock.enableNetConnect()
+  })
+})

--- a/test/track-versions.test.js
+++ b/test/track-versions.test.js
@@ -32,7 +32,7 @@ describe('track-versions', () => {
       name: 'push',
       payload: {
         ref: 'refs/heads/master',
-        head: 'asdfasdfasdfasdfasdf',
+        after: 'asdfasdfasdfasdfasdf',
         repository: {
           name: 'testrepo',
           full_name: 'testowner/testrepo',
@@ -64,7 +64,7 @@ describe('track-versions', () => {
       name: 'push',
       payload: {
         ref: 'refs/heads/master',
-        head: 'asdfasdfasdfasdfasdf',
+        after: 'asdfasdfasdfasdfasdf',
         repository: {
           name: 'testotherrepo',
           full_name: 'testowner/testotherrepo',
@@ -85,7 +85,7 @@ describe('track-versions', () => {
       name: 'push',
       payload: {
         ref: 'refs/heads/master',
-        head: 'asdfasdfasdfasdfasdf',
+        after: 'asdfasdfasdfasdfasdf',
         repository: {
           full_name: 'testowner/randomrepo',
           name: 'randomrepo',

--- a/test/utils/prIsReadyForAutoMerge.test.js
+++ b/test/utils/prIsReadyForAutoMerge.test.js
@@ -70,7 +70,7 @@ describe('isReadyForAutoMerge', () => {
 
     const result = await isReadyForAutoMerge(
       github,
-      {...pullRequest, body: 'for: openstax/rex-web#123', labels: [{name: 'ready to merge'}]},
+      {...pullRequest, body: 'for: openstax/rex-web#123', labels: [{name: 'ready to merge'}]}
     )
 
     expect(github.issues.get).toHaveBeenCalledTimes(1)

--- a/test/utils/versionsBlock.test.js
+++ b/test/utils/versionsBlock.test.js
@@ -2,8 +2,8 @@ const {getVersions, getVersion, setVersions, setVersion} = require('../../src/ut
 
 const exampleBlock = `# versions
 - openstax/rex-web (sha): dfde202
-- openstax/rex-web (release id): master/dfde202
-- openstax/highlights-api (sha): 8575ef7
+- openstax/rex-web (release id): master/dfde202 locked
+- openstax/highlights-api (sha): 8575ef7 locked
 - openstax/highlights-api (ami): ami-000167d12cf19dce1
 `
 
@@ -66,6 +66,29 @@ describe('getVersion', () => {
 describe('setVersions', () => {
   test('sets versions', () => {
     const newVersions = {...expected, 'openstax/rex-web (sha)': 'foobar'}
+    const result = setVersions(`asdf
+asdf
+${exampleBlock}asdf
+asdf
+`, newVersions)
+    expect(result).toEqual(`asdf
+asdf
+# versions
+- openstax/rex-web (sha): foobar
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+asdf
+`)
+  })
+
+  test('noops locked versions', () => {
+    const newVersions = {
+      ...expected,
+      'openstax/rex-web (sha)': 'foobar',
+      'openstax/rex-web (release id)': 'foobar2'
+    }
     const result = setVersions(`asdf
 asdf
 ${exampleBlock}asdf

--- a/test/utils/versionsBlock.test.js
+++ b/test/utils/versionsBlock.test.js
@@ -1,0 +1,177 @@
+const {getVersions, getVersion, setVersions, setVersion} = require('../../src/utils/versionsBlock')
+
+const exampleBlock = `# versions
+- openstax/rex-web (sha): dfde202
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+`
+
+const expected = {
+  'openstax/rex-web (sha)': 'dfde202',
+  'openstax/rex-web (release id)': 'master/dfde202',
+  'openstax/highlights-api (sha)': '8575ef7',
+  'openstax/highlights-api (ami)': 'ami-000167d12cf19dce1',
+}
+
+describe('getVersions', () => {
+  test('resolves basic block', () => {
+    const result = getVersions(exampleBlock)
+    expect(result).toEqual(expected)
+  })
+
+  test('resolves with text before', () => {
+    const result = getVersions('asdf\n\rasdf\n\rasdf\n\r' + exampleBlock)
+    expect(result).toEqual(expected)
+  })
+
+  test('resolves with text around', () => {
+    const result = getVersions('asdf\n\rasdf\n\rasdf\n\r' + exampleBlock + 'asdf\n\rasdf\n\rasdf\n\r')
+    expect(result).toEqual(expected)
+  })
+
+  test('resolves with text after', () => {
+    const result = getVersions(exampleBlock + 'asdf\n\rasdf\n\rasdf\n\r')
+    expect(result).toEqual(expected)
+  })
+
+  test('pipeline title must be on ownline', () => {
+    const result = getVersions('asdf\n\rasdf\n\rasdf' + exampleBlock)
+    expect(result).toEqual(null)
+  })
+
+  test('doesn\'t match pr block', () => {
+    const result = getVersions('pull requests: \n- [ ] https://github.com/openstax/rex-web/pulls/123')
+    expect(result).toEqual(null)
+  })
+
+  test('doesn\'t match pr block earlier in body', () => {
+    const result = getVersions('pull requests: \n- [ ] https://github.com/openstax/rex-web/pulls/123\n\radsf\n\r' + exampleBlock)
+    expect(result).toEqual(expected)
+  })
+})
+
+describe('getVersion', () => {
+  test('gets version', () => {
+    const result = getVersion(exampleBlock, 'openstax/highlights-api (ami)')
+    expect(result).toEqual('ami-000167d12cf19dce1')
+  })
+
+  test('returns undefined if not found', () => {
+    const result = getVersion(exampleBlock, 'asdfasdf')
+    expect(result).toEqual(undefined)
+  })
+})
+
+describe('setVersions', () => {
+  test('sets versions', () => {
+    const newVersions = {...expected, 'openstax/rex-web (sha)': 'foobar'}
+    const result = setVersions(`asdf
+asdf
+${exampleBlock}asdf
+asdf
+`, newVersions)
+    expect(result).toEqual(`asdf
+asdf
+# versions
+- openstax/rex-web (sha): foobar
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+asdf
+`)
+  })
+
+  test('adds versions block if initially unset', () => {
+    const result = setVersions(`asdf
+asdf
+asdf
+`, expected)
+    expect(result).toEqual(`asdf
+asdf
+asdf
+
+
+versions:
+- openstax/rex-web (sha): dfde202
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1`
+    )
+  })
+
+  test('adds versions to the block', () => {
+    const result = setVersions(`asdf
+asdf
+# versions
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+`, expected)
+    expect(result).toEqual(`asdf
+asdf
+# versions
+- openstax/rex-web (sha): dfde202
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+`
+    )
+  })
+})
+
+describe('setVersion', () => {
+  test('sets version', () => {
+    const result = setVersion(`asdf
+asdf
+${exampleBlock}asdf
+asdf
+`, 'openstax/rex-web (sha)', 'foobar')
+    expect(result).toEqual(`asdf
+asdf
+# versions
+- openstax/rex-web (sha): foobar
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (sha): 8575ef7
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+asdf
+`)
+  })
+
+  test('adds versions block if initially unset', () => {
+    const result = setVersion(`asdf
+asdf
+asdf
+`, 'openstax/rex-web (sha)', 'foobar')
+    expect(result).toEqual(`asdf
+asdf
+asdf
+
+
+versions:
+- openstax/rex-web (sha): foobar`
+    )
+  })
+
+  test('adds versions to the block', () => {
+    const result = setVersion(`asdf
+asdf
+# versions
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+asdf
+`, 'openstax/rex-web (sha)', 'foobar')
+    expect(result).toEqual(`asdf
+asdf
+# versions
+- openstax/rex-web (release id): master/dfde202
+- openstax/highlights-api (ami): ami-000167d12cf19dce1
+- openstax/rex-web (sha): foobar
+asdf
+`
+    )
+  })
+})

--- a/test/utils/versionsBlock.test.js
+++ b/test/utils/versionsBlock.test.js
@@ -11,7 +11,7 @@ const expected = {
   'openstax/rex-web (sha)': 'dfde202',
   'openstax/rex-web (release id)': 'master/dfde202',
   'openstax/highlights-api (sha)': '8575ef7',
-  'openstax/highlights-api (ami)': 'ami-000167d12cf19dce1',
+  'openstax/highlights-api (ami)': 'ami-000167d12cf19dce1'
 }
 
 describe('getVersions', () => {


### PR DESCRIPTION
when a configured set of repositories `master` branch is updated, update versions in all open release cards

use cases:
- less hunting for most recent versions when populating release cards for devops
- future automation will use the release cards to coordinate deployments and create release candidate environments.

example release card https://github.com/TomWoodward/testing-stuff/issues/11