### PR TITLE
Handle merge error

### DIFF
--- a/src/auto-merge.js
+++ b/src/auto-merge.js
@@ -65,7 +65,7 @@ module.exports = (robot) => {
               owner: pullParams.owner,
               repo: pullParams.repo,
               issue_number: pullParams.pull_number,
-              name: readyToMergeLabel,
+              name: readyToMergeLabel
             })
           }
         })

--- a/src/merge-bases.js
+++ b/src/merge-bases.js
@@ -24,10 +24,10 @@ module.exports = (robot) => {
       })
         .catch(error => {
           if (error.status === 422) {
-            // 422 is returned when there is a merge conflict, don't explode on these errors 
-            logger.info(`github response (422): ${error.message}`);
+            // 422 is returned when there is a merge conflict, don't explode on these errors
+            logger.info(`github response (422): ${error.message}`)
           } else {
-            return Promise.reject(error);
+            return Promise.reject(error)
           }
         })
     }))

--- a/src/merge-bases.js
+++ b/src/merge-bases.js
@@ -22,6 +22,14 @@ module.exports = (robot) => {
         repo,
         pull_number: pr.number
       })
+        .catch(error => {
+          if (error.status === 422) {
+            // 422 is returned when there is a merge conflict, don't explode on these errors 
+            logger.info(`github response (422): ${error.message}`);
+          } else {
+            return Promise.reject(error);
+          }
+        })
     }))
   }
 

--- a/src/utils/prIsReadyForAutoMerge.js
+++ b/src/utils/prIsReadyForAutoMerge.js
@@ -52,5 +52,5 @@ const prIsReadyForAutoMerge = async (github, pullRequest, optionalIssue) => {
 
 module.exports = {
   prIsReadyForAutoMerge,
-  readyToMergeLabel,
-};
+  readyToMergeLabel
+}


### PR DESCRIPTION
probot doesn't catch errors and continue onto other event listeners if one throws an error, so we need to be careful to catch any reasonably common or expected errors