### PR TITLE
don't automatically merge bases for draft prs

### DIFF
--- a/src/merge-bases.js
+++ b/src/merge-bases.js
@@ -50,6 +50,7 @@ module.exports = (robot) => {
         owner,
         repo,
         base,
+        draft: false,
         state: 'open'
       }),
       processPrs(context)

--- a/test/merge-bases.test.js
+++ b/test/merge-bases.test.js
@@ -13,7 +13,7 @@ describe('My Probot app', () => {
 
   test('updates branch', async () => {
     nock('https://api.github.com')
-      .get('/repos/testowner/testrepo/pulls?base=master&state=open')
+      .get('/repos/testowner/testrepo/pulls?base=master&state=open&draft=false')
       .reply(200, [{number: 5}])
 
     nock('https://api.github.com')


### PR DESCRIPTION
i've started opening a lot of draft prs and its causing CI to slow down now