### PR TITLE
handle commit status updates

### DIFF
--- a/src/auto-merge.js
+++ b/src/auto-merge.js
@@ -19,6 +19,26 @@ module.exports = (robot) => {
     return handler(context)
   })
 
+  safeBind(['status'], context => {
+    const branches = context.payload.branches
+
+    if (branches.length !== 1) {
+      return
+    }
+
+    const [branch] = branches
+    return context.github.pulls.list({...context.repo(), head: `openstax:${branch.name}`}).then(response => {
+      const prs = response.data
+      if (prs.length !== 1) {
+        return
+      }
+
+      const [pr] = prs
+      const pullParams = {pull_number: pr.number, ...context.repo()}
+      return checkPR(context, pullParams, pr)
+    })
+  })
+
   safeBind(['check_suite.completed'], context =>
     Promise.all(context.payload.pull_requests.map(pr => {
       const pullParams = {pull_number: pr.number, ...context.repo()}

--- a/src/utils/prIsReadyForAutoMerge.js
+++ b/src/utils/prIsReadyForAutoMerge.js
@@ -7,7 +7,7 @@ const hasSubChanges = (github, pullRequest) => github.pulls.list({
   base: pullRequest.head.ref,
   state: 'open'
 })
-  .then(prs => prs.length > 0)
+  .then(response => response.data.length > 0)
 
 const readyToMergeLabel = 'ready to merge'
 

--- a/test/utils/prIsReadyForAutoMerge.test.js
+++ b/test/utils/prIsReadyForAutoMerge.test.js
@@ -49,7 +49,7 @@ describe('prIsReadyForAutoMerge', () => {
         get: jest.fn()
       },
       pulls: {
-        list: jest.fn(() => Promise.resolve([]))
+        list: jest.fn(() => Promise.resolve({data: []}))
       }
     }
   })
@@ -129,7 +129,7 @@ describe('prIsReadyForAutoMerge', () => {
   })
 
   test('fails if pr has sub changes', async () => {
-    github.pulls.list.mockReturnValue(Promise.resolve([pullRequest]))
+    github.pulls.list.mockReturnValue(Promise.resolve({data: [pullRequest]}))
 
     const result = await prIsReadyForAutoMerge(
       github,


### PR DESCRIPTION
some CI checks use commit statuses instead of the checks api, this catches those updates

also some older code was just wrong, so i fixed that