### PR TITLE
Use repos' default branches in track-versions.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,7 +9,6 @@ import slackStuff from './slack-stuff.js'
 const { IGNORE_FOR_TESTING } = process.env
 
 export default (robot, { getRouter }) => {
-
   changelog(robot)
   mergeBases(robot)
   linkIssues(robot)

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -15,6 +15,9 @@ const releaseCardRepos = {
     'openstax/accounts-deployment',
     'openstax/accounts'
   ],
+  'philschatz/staxly-test': [
+    'philschatz/staxly-test'
+  ],
   'TomWoodward/testing-stuff': [
     'TomWoodward/testing-stuff'
   ]

--- a/src/track-versions.js
+++ b/src/track-versions.js
@@ -60,7 +60,7 @@ export default (robot) => {
     const versionKey = repo
     const version = payload.after
 
-    if (branch !== 'master') {
+    if (branch !== payload.repository.default_branch) {
       return
     }
 

--- a/test/corgi-tag-watcher.test.js
+++ b/test/corgi-tag-watcher.test.js
@@ -4,159 +4,156 @@ const nock = require('nock')
 const { Probot, createProbot } = require('probot')
 
 const base = {
-    name: 'testrepo',
-    owner: {
-        login: 'testowner'
-    }
+  name: 'testrepo',
+  owner: {
+    login: 'testowner'
+  }
 }
 
 describe('tag trigger', () => {
-    let app
+  let app
 
-    beforeEach(() => {
-        nock.disableNetConnect()
-        process.env.CORGI_HOSTNAME = 'corgi-hostname'
-        process.env.CORGI_SLACK_SECRET = 'dummy-secret'
+  beforeEach(() => {
+    nock.disableNetConnect()
+    process.env.CORGI_HOSTNAME = 'corgi-hostname'
+    process.env.CORGI_SLACK_SECRET = 'dummy-secret'
 
+    app = new Probot({ appId: 1234, cert: 'test', githubToken: 'test' })
+    app.load(corgiTagWatcher)
+  })
 
+  afterEach(() => {
+    nock.cleanAll()
+  })
 
-        app = new Probot({ appId: 1234, cert: 'test', githubToken: 'test' })
-        app.load(corgiTagWatcher)
-    })
-
-    afterEach(() => {
-        nock.cleanAll()
-    })
-
-    test('does nothing if payload.reftype is not tag', async () => {
-        const xml = `<container>
+  test('does nothing if payload.reftype is not tag', async () => {
+    const xml = `<container>
                         <book slug="book-slug1" href="../collections/book-slug1.collection.xml" />
                     </container>`
-        const github = nock('https://api.github.com')
-            .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
-            .reply(200, {
-                "content": Buffer.from(xml).toString('base64'),
-                "encoding": "base64",
-            })
+    const github = nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
+      .reply(200, {
+        content: Buffer.from(xml).toString('base64'),
+        encoding: 'base64'
+      })
 
-        const corgi = nock('https://corgi-hostname')
-            .post('/api/jobs/')
-            .reply(200, {})
+    const corgi = nock('https://corgi-hostname')
+      .post('/api/jobs/')
+      .reply(200, {})
 
-        const slack = nock('https://hooks.slack.com')
-            .post('/services/dummy-secret')
-            .reply(200, {})
+    const slack = nock('https://hooks.slack.com')
+      .post('/services/dummy-secret')
+      .reply(200, {})
 
-        await app.receive({
-            name: 'create',
-            payload: {
-                ref: 'refs/heads/main',
-                ref_type: 'branch',
-                master_branch: 'main',
-                description: 'asdf',
-                repository: base
-            }
-        })
-
-        expect(github.isDone()).toBe(false)
+    await app.receive({
+      name: 'create',
+      payload: {
+        ref: 'refs/heads/main',
+        ref_type: 'branch',
+        master_branch: 'main',
+        description: 'asdf',
+        repository: base
+      }
     })
 
-    test('queues job with corgi if payload.reftype is tag', async () => {
-        const xml = `<container>
+    expect(github.isDone()).toBe(false)
+  })
+
+  test('queues job with corgi if payload.reftype is tag', async () => {
+    const xml = `<container>
                         <book slug="book-slug1" href="../collections/book-slug1.collection.xml" />
                     </container>`
-        const github = nock('https://api.github.com')
-            .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
-            .reply(200, {
-                "content": Buffer.from(xml).toString('base64'),
-                "encoding": "base64",
-            })
+    const github = nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
+      .reply(200, {
+        content: Buffer.from(xml).toString('base64'),
+        encoding: 'base64'
+      })
 
-        const corgi = nock('https://corgi-hostname')
-            .post('/api/jobs/')
-            .reply(200, {})
+    const corgi = nock('https://corgi-hostname')
+      .post('/api/jobs/')
+      .reply(200, {})
 
-        const slack = nock('https://hooks.slack.com')
-            .post('/services/dummy-secret')
-            .reply(200, {})
+    const slack = nock('https://hooks.slack.com')
+      .post('/services/dummy-secret')
+      .reply(200, {})
 
-        await app.receive({
-            name: 'create',
-            payload: {
-                ref: 'refs/heads/main',
-                ref_type: 'tag',
-                master_branch: 'main',
-                description: 'asdf',
-                repository: base
-            }
-        })
-
-        expect(corgi.isDone()).toBe(true)
+    await app.receive({
+      name: 'create',
+      payload: {
+        ref: 'refs/heads/main',
+        ref_type: 'tag',
+        master_branch: 'main',
+        description: 'asdf',
+        repository: base
+      }
     })
 
-    test('notifies slack if corgi job successfully queues', async () => {
-        const xml = `<container>
+    expect(corgi.isDone()).toBe(true)
+  })
+
+  test('notifies slack if corgi job successfully queues', async () => {
+    const xml = `<container>
                         <book slug="book-slug1" href="../collections/book-slug1.collection.xml" />
                     </container>`
-        const github = nock('https://api.github.com')
-            .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
-            .reply(200, {
-                "content": Buffer.from(xml).toString('base64'),
-                "encoding": "base64",
-            })
+    const github = nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
+      .reply(200, {
+        content: Buffer.from(xml).toString('base64'),
+        encoding: 'base64'
+      })
 
-        const corgi = nock('https://corgi-hostname')
-            .post('/api/jobs/')
-            .reply(200, {})
+    const corgi = nock('https://corgi-hostname')
+      .post('/api/jobs/')
+      .reply(200, {})
 
-        const slack = nock('https://hooks.slack.com')
-            .post('/services/dummy-secret')
-            .reply(200, {})
+    const slack = nock('https://hooks.slack.com')
+      .post('/services/dummy-secret')
+      .reply(200, {})
 
-        await app.receive({
-            name: 'create',
-            payload: {
-                ref: 'refs/heads/main',
-                ref_type: 'tag',
-                master_branch: 'main',
-                description: 'asdf',
-                repository: base
-            }
-        })
-
-        expect(slack.isDone()).toBe(true)
+    await app.receive({
+      name: 'create',
+      payload: {
+        ref: 'refs/heads/main',
+        ref_type: 'tag',
+        master_branch: 'main',
+        description: 'asdf',
+        repository: base
+      }
     })
-    test('notifies slack if corgi job fails to queue', async () => {
-        const xml = `<container>
+
+    expect(slack.isDone()).toBe(true)
+  })
+  test('notifies slack if corgi job fails to queue', async () => {
+    const xml = `<container>
                         <book slug="book-slug1" href="../collections/book-slug1.collection.xml" />
                     </container>`
-        const github = nock('https://api.github.com')
-            .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
-            .reply(200, {
-                "content": Buffer.from(xml).toString('base64'),
-                "encoding": "base64",
-            })
+    const github = nock('https://api.github.com')
+      .get('/repos/testowner/testrepo/contents/META-INF%2Fbooks.xml')
+      .reply(200, {
+        content: Buffer.from(xml).toString('base64'),
+        encoding: 'base64'
+      })
 
-        const corgi = nock('https://corgi-hostname')
-            .post('/api/jobs/')
-            .reply(500, {})
+    const corgi = nock('https://corgi-hostname')
+      .post('/api/jobs/')
+      .reply(500, {})
 
-        const slack = nock('https://hooks.slack.com')
-            .post('/services/dummy-secret')
-            .reply(200, {})
+    const slack = nock('https://hooks.slack.com')
+      .post('/services/dummy-secret')
+      .reply(200, {})
 
-        await app.receive({
-            name: 'create',
-            payload: {
-                ref: 'refs/heads/main',
-                ref_type: 'tag',
-                master_branch: 'main',
-                description: 'asdf',
-                repository: base
-            }
-        })
-
-        expect(slack.isDone()).toBe(true)
+    await app.receive({
+      name: 'create',
+      payload: {
+        ref: 'refs/heads/main',
+        ref_type: 'tag',
+        master_branch: 'main',
+        description: 'asdf',
+        repository: base
+      }
     })
 
+    expect(slack.isDone()).toBe(true)
+  })
 })

--- a/test/track-versions.test.js
+++ b/test/track-versions.test.js
@@ -33,14 +33,15 @@ describe('track-versions', () => {
     await app.receive({
       name: 'push',
       payload: {
-        ref: 'refs/heads/master',
+        ref: 'refs/heads/main',
         after: 'asdfasdfasdfasdfasdf',
         repository: {
           name: 'testrepo',
           full_name: 'testowner/testrepo',
           owner: {
             name: 'testowner'
-          }
+          },
+          default_branch: 'main'
         }
       }
     })
@@ -72,7 +73,8 @@ describe('track-versions', () => {
           full_name: 'testowner/testotherrepo',
           owner: {
             name: 'testowner'
-          }
+          },
+          default_branch: 'master'
         }
       }
     })
@@ -98,7 +100,28 @@ describe('track-versions', () => {
           full_name: 'testowner/testotherrepo',
           owner: {
             name: 'testowner'
-          }
+          },
+          default_branch: 'master'
+        }
+      }
+    })
+
+    expect(nock.isDone()).toBe(true)
+  })
+
+  test('noops pushes to non-default branches', async () => {
+    await app.receive({
+      name: 'push',
+      payload: {
+        ref: 'refs/heads/master',
+        after: 'asdfasdfasdfasdfasdf',
+        repository: {
+          name: 'testotherrepo',
+          full_name: 'testowner/testotherrepo',
+          owner: {
+            name: 'testowner'
+          },
+          default_branch: 'main'
         }
       }
     })
@@ -117,7 +140,8 @@ describe('track-versions', () => {
           name: 'randomrepo',
           owner: {
             name: 'testowner'
-          }
+          },
+          default_branch: 'master'
         }
       }
     })


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/1774
Also fixed failing `yarn lint` in a test.
Tested using this test release: https://github.com/philschatz/staxly-test/issues/134