### PR TITLE
:bug: fix the import

### DIFF
--- a/src/utils/versionsBlock.js
+++ b/src/utils/versionsBlock.js
@@ -1,4 +1,4 @@
-import { getItems, getItemValue, setItems } from './configBlock'
+import { getItems, getItemValue, setItems } from './configBlock.js'
 
 export const getVersions = (body, filter = () => true) => {
   const items = getItems(body, 'versions', filter)


### PR DESCRIPTION
The import is missing a `.js` at the end which causes the app to crash.

Logs:

```
2024-06-13T16:27:15.492599+00:00 heroku[web.1]: State changed from starting to crashed
2024-06-13T16:27:33.670433+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/" host=staxly-pipel-update-nod-svuawo.herokuapp.com request_id=8e908c0e-c08c-4c18-b4dc-15964f2ada86 fwd="97.115.238.0" dyno= connect= service= status=503 bytes= protocol=https
2024-06-13T16:27:34.159700+00:00 heroku[router]: at=error code=H10 desc="App crashed" method=GET path="/favicon.ico" host=staxly-pipel-update-nod-svuawo.herokuapp.com request_id=72da1c71-8c59-46ce-a009-cbc73da2f903 fwd="97.115.238.0" dyno= connect= service= status=503 bytes= protocol=https
2024-06-13T16:28:13.524958+00:00 heroku[web.1]: State changed from crashed to starting
2024-06-13T16:28:17.957572+00:00 heroku[web.1]: Starting process with command `npm start`
2024-06-13T16:28:19.105879+00:00 app[web.1]: 
2024-06-13T16:28:19.105955+00:00 app[web.1]: > staxly@1.0.0 start
2024-06-13T16:28:19.105955+00:00 app[web.1]: > probot run ./index.cjs
2024-06-13T16:28:19.105956+00:00 app[web.1]: 
2024-06-13T16:28:19.489497+00:00 app[web.1]: Error [ERR_MODULE_NOT_FOUND]: Cannot find module '/app/src/utils/configBlock' imported from /app/src/utils/versionsBlock.js
2024-06-13T16:28:19.489529+00:00 app[web.1]:     at finalizeResolution (node:internal/modules/esm/resolve:265:11)
2024-06-13T16:28:19.489531+00:00 app[web.1]:     at moduleResolve (node:internal/modules/esm/resolve:933:10)
2024-06-13T16:28:19.489531+00:00 app[web.1]:     at defaultResolve (node:internal/modules/esm/resolve:1157:11)
2024-06-13T16:28:19.489531+00:00 app[web.1]:     at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:383:12)
2024-06-13T16:28:19.489531+00:00 app[web.1]:     at ModuleLoader.resolve (node:internal/modules/esm/loader:352:25)
2024-06-13T16:28:19.489532+00:00 app[web.1]:     at ModuleLoader.getModuleJob (node:internal/modules/esm/loader:227:38)
2024-06-13T16:28:19.489532+00:00 app[web.1]:     at ModuleWrap.<anonymous> (node:internal/modules/esm/module_job:87:39)
2024-06-13T16:28:19.489532+00:00 app[web.1]:     at link (node:internal/modules/esm/module_job:86:36) {
2024-06-13T16:28:19.489536+00:00 app[web.1]:   code: 'ERR_MODULE_NOT_FOUND',
2024-06-13T16:28:19.489536+00:00 app[web.1]:   url: 'file:///app/src/utils/configBlock'
2024-06-13T16:28:19.489538+00:00 app[web.1]: }
2024-06-13T16:28:19.503661+00:00 app[web.1]: npm notice
2024-06-13T16:28:19.503663+00:00 app[web.1]: npm notice New minor version of npm available! 10.7.0 -> 10.8.1
2024-06-13T16:28:19.503663+00:00 app[web.1]: npm notice Changelog: https://github.com/npm/cli/releases/tag/v10.8.1
2024-06-13T16:28:19.503664+00:00 app[web.1]: npm notice To update run: npm install -g npm@10.8.1
2024-06-13T16:28:19.503664+00:00 app[web.1]: npm notice
2024-06-13T16:28:19.568279+00:00 heroku[web.1]: Process exited with status 1
2024-06-13T16:28:19.588705+00:00 heroku[web.1]: State changed from starting to crashed
```